### PR TITLE
T-10 conditional Dockerfiles and docker-compose for dev and prod

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-slim as base
 
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
@@ -14,6 +14,21 @@ RUN pip3 install -r ./requirements.txt
 COPY ./core/ .
 # COPY ./entrypoint.sh .
 
+FROM base as development
+RUN chmod +x /usr/src/app/entrypoint.sh
+# this is honestly massive **** but there's no other way how to do it...
+# django-graphene package is not compatible with django 4.0 and since django 4.0 ang graphql-core deprecated the use of format_error function 
+# this has to be done...
+# the following code replaces import of format_error from graphql.error with import of GraphQLFormattedError in graphql-graphene views
+# otherwise grapql views cannot be imported
+# RUN sed -i "/from graphql.error import format_error as format_graphql_error/c\from graphql.error import GraphQLFormattedError as format_graphql_error" /usr/local/lib/python3.9/site-packages/graphene_django/views.py
+ENTRYPOINT [ "sh", "/usr/src/app/entrypoint.sh" ]
+# ENTRYPOINT ["tail", "-f", "/dev/null"]
+
+
+# Production branch of a Dockerfile
+# It's currently the same as development branch above but it's here for future use
+FROM base as production
 RUN chmod +x /usr/src/app/entrypoint.sh
 # this is honestly massive **** but there's no other way how to do it...
 # django-graphene package is not compatible with django 4.0 and since django 4.0 ang graphql-core deprecated the use of format_error function 

--- a/src/dashboard/Dockerfile
+++ b/src/dashboard/Dockerfile
@@ -10,18 +10,17 @@ RUN npm install --legacy-peer-deps
 # builder
 FROM dependencies as builder
 WORKDIR /usr/src/app
-
 COPY . .
 
-# RUN npm run build 
-
-# runner
-FROM builder as runner
+# development environment
+FROM builder as development
 WORKDIR /usr/src/app
-# ENV NODE_ENV production
 ENV NODE_ENV development
-
-
-
-# CMD ["npm", "start"]
 CMD ["npm", "run", "dev"]
+
+# production environment
+FROM builder as production
+WORKDIR /usr/src/app
+ENV NODE_ENV production
+RUN npm run build
+CMD ["npm", "start"]

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -3,7 +3,9 @@ version: "3.9"
 services:
   backend:
       container_name: backend
-      build: ./backend
+      build: 
+        context: ./backend
+        target: development
       volumes:
         - ./backend/core:/usr/src/app/
       ports:
@@ -12,7 +14,9 @@ services:
         - ./backend/docker-compose.env
   frontend_dashboard:
       container_name: dashboard
-      build: ./dashboard
+      build: 
+        context: ./dashboard
+        target: production # runs given branch in Dockerfile https://stackoverflow.com/a/65624157/16587316
       environment:
         CHOKIDAR_USEPOLLING: "true" # https://stackoverflow.com/questions/61576659/how-to-hot-reload-in-reactjs-docker
       volumes:
@@ -28,7 +32,9 @@ services:
         - backend
   frontend_storefront:
       container_name: storefront
-      build: ./storefront
+      build: 
+        context: ./storefront
+        target: development # runs given branch in Dockerfile https://stackoverflow.com/a/65624157/16587316
       environment:
         CHOKIDAR_USEPOLLING: "true" # https://stackoverflow.com/questions/61576659/how-to-hot-reload-in-reactjs-docker
       volumes:

--- a/src/storefront/Dockerfile
+++ b/src/storefront/Dockerfile
@@ -10,19 +10,17 @@ RUN npm install --legacy-peer-deps
 # builder
 FROM dependencies as builder
 WORKDIR /usr/src/app
-
 COPY . .
 
-# RUN npm run build 
-
-# runner
-FROM builder as runner
+# development environment
+FROM builder as development
 WORKDIR /usr/src/app
-# ENV NODE_ENV production
 ENV NODE_ENV development
-# EXPOSE 3000
-
-
-
-# CMD ["npm", "start"]
 CMD ["npm", "run", "dev"]
+
+# production environment
+FROM builder as production
+WORKDIR /usr/src/app
+ENV NODE_ENV production
+RUN npm run build
+CMD ["npm", "start"]


### PR DESCRIPTION
Added 
```docker-compose
build: 
        context: ./storefront
        target: development # or production
```
scope for all backend, storefront and dashboard docker-compose services and created two branches (`development`/`production`) in every Dockerfile for mentioned services that either runs production build or developement mode.
For `django` this is a future work since we don't have reverse proxy yet that could be started (or some wsgi) in production so both branches are the same. But Dashboard and Storefront svcs are ready.