### PR TITLE
[T-83] added remote debugging with docker for vscode

### DIFF
--- a/src/backend/core/core/settings.py
+++ b/src/backend/core/core/settings.py
@@ -124,12 +124,12 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.BasicAuthentication",
-        "rest_framework.authentication.TokenAuthentication",
+        # "rest_framework.authentication.TokenAuthentication",
+        # "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.AllowAny",
-        "rest_framework_simplejwt.authentication.JWTAuthentication",
-        "rest_framework.permissions.IsAuthenticated",
+        # "rest_framework.permissions.IsAuthenticated",
     ],
 }
 

--- a/src/backend/core/manage.py
+++ b/src/backend/core/manage.py
@@ -12,6 +12,7 @@ def main():
     if settings.DEBUG:
         if os.environ.get("RUN_MAIN") or os.environ.get("WERKZEUG_RUN_MAIN"):
             import debugpy
+
             debugpy.listen(("0.0.0.0", 8001))
             debugpy.wait_for_client()
             print("Attached!")

--- a/src/backend/core/manage.py
+++ b/src/backend/core/manage.py
@@ -14,7 +14,6 @@ def main():
             import debugpy
 
             debugpy.listen(("0.0.0.0", 8001))
-            debugpy.wait_for_client()
             print("Attached!")
 
     try:

--- a/src/backend/core/manage.py
+++ b/src/backend/core/manage.py
@@ -2,11 +2,20 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
+from django.conf import settings
 
 
 def main():
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
+
+    if settings.DEBUG:
+        if os.environ.get("RUN_MAIN") or os.environ.get("WERKZEUG_RUN_MAIN"):
+            import debugpy
+            debugpy.listen(("0.0.0.0", 8001))
+            debugpy.wait_for_client()
+            print("Attached!")
+
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -54,5 +54,6 @@ urllib3==1.26.12
 wrapt==1.14.1
 zipp==3.8.0
 djangorestframework-simplejwt==5.2.2
+debugpy==1.6.6
 # lxml==4.8.0
 # graphene-django==3.0.0b7 # https://github.com/graphql-python/graphene-django/pull/1275

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
         - ./backend/core:/usr/src/app/
       ports:
         - 8000:8000
+        - 8001:8001
       env_file:
         - ./backend/docker-compose.env
   frontend_dashboard:


### PR DESCRIPTION
As this is vscode specific and we have vscode related files in gitignore, for this to work correctly it will also require following launch.json file:
{
    "version": "0.2.0",
    "configurations": [
      {
        "name": "Run Django",
        "type": "python",
        "request": "attach",
        "pathMappings": [
          {
            "localRoot": "${workspaceFolder}/src/backend/core",
            "remoteRoot": "/usr/src/app"
          }
        ],
        "port": 8001,
        "host": "127.0.0.1",
      }
    ]
}