### PR TITLE
T-112: added price matrix editor

### DIFF
--- a/src/dashboard/components/Dashboard/Catalog/Products/Editor/Product/ProductVariantPricesEditor.tsx
+++ b/src/dashboard/components/Dashboard/Catalog/Products/Editor/Product/ProductVariantPricesEditor.tsx
@@ -1,20 +1,171 @@
 import CollapsableContentWithTitle from "@/components/Dashboard/Generic/CollapsableContentWithTitle";
 import EditorCard from "@/components/Dashboard/Generic/EditorCard";
-import { ISetProductStateData } from "@/types/product";
+import { IPriceList } from "@/types/localization";
+import {
+  ActionSetProduct,
+  IProductVariant,
+  ISetProductStateData,
+} from "@/types/product";
+import {
+  deserializeProductVariantAttributesToRow,
+  deserializeProductVariantPricesToRow,
+  serializeProductVariantPricesFromRow,
+} from "@/utils/productSerializer";
 import Typography from "@mui/material/Typography";
+import { DataGrid } from "@mui/x-data-grid/DataGrid";
+import {
+  GridColDef,
+  GridEventListener,
+  GridRowModesModel,
+  GridRowParams,
+  MuiEvent,
+} from "@mui/x-data-grid/models";
+import { useEffect, useState } from "react";
 import { ISetProductStateAction } from "../ProductEditorWrapper";
 
 interface IProductVariantPriceEditorProps {
   disabled: boolean;
   state: ISetProductStateData;
   dispatch: React.Dispatch<ISetProductStateAction>;
+  pricelistsData: IPriceList[];
+}
+
+interface IProductVariantPriceTable extends IProductVariant {
+  id: string;
 }
 
 const ProductVariantPricesEditor = ({
   disabled,
   state,
   dispatch,
+  pricelistsData,
 }: IProductVariantPriceEditorProps) => {
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: "success" | "error" | "info" | "warning";
+  } | null>(null);
+
+  const [rows, setRows] = useState<IProductVariantPriceTable[]>([]);
+
+  const [updateMainState, setUpdateMainState] = useState<boolean>(false);
+
+  const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
+
+  useEffect(() => {
+    console.log("updateMainState-UpdatingPriceRows", updateMainState);
+    if (state.product_variants) {
+      setRows(
+        state.product_variants.map((productVariant: IProductVariant) => ({
+          id: productVariant.sku,
+          sku: productVariant.sku,
+          ...deserializeProductVariantPricesToRow(
+            productVariant,
+            pricelistsData
+          ),
+        }))
+      );
+    }
+  }, [state.product_variants]);
+
+  useEffect(() => {
+    // when the rows change, we need to serialize the attributes and prices and then dispatch the action
+    // to set the product_variants in the state
+    if (!updateMainState) {
+      return;
+    }
+    console.log("updateMainState-Price", updateMainState);
+
+    setUpdateMainState(false);
+    if (!rows || rows?.length == 0) {
+      dispatch({
+        type: ActionSetProduct.SETPRODUCTVARIANTS,
+        payload: { product_variants: [] },
+      });
+      return;
+    }
+    console.log("settingrows", rows);
+
+    const variantsToSet = rows.map(
+      (row) =>
+        ({
+          ...(row as IProductVariant),
+          price: serializeProductVariantPricesFromRow(row, pricelistsData),
+        } as IProductVariant)
+    );
+    console.log("settingrows2", rows, variantsToSet);
+
+    dispatch({
+      type: ActionSetProduct.SETPRODUCTVARIANTS,
+      payload: {
+        product_variants: variantsToSet,
+      },
+    });
+  }, [updateMainState]);
+
+  const columns: GridColDef[] = [
+    {
+      field: "sku",
+      headerName: "SKU",
+      editable: false,
+      width: 125,
+      minWidth: 150,
+      maxWidth: 200,
+      sortable: false,
+      disableColumnMenu: true,
+    },
+    ...(pricelistsData
+      ? pricelistsData?.map((pricelist: IPriceList) => ({
+          field: `$PRICE_${pricelist.code}`,
+          headerName: pricelist.code,
+          editable: true,
+          width: 125,
+          minWidth: 150,
+          maxWidth: 200,
+          sortable: false,
+          disableColumnMenu: true,
+        }))
+      : []), // <-- this generates pricelist columns
+  ];
+
+  const handleRowModesModelChange = (newRowModesModel: GridRowModesModel) => {
+    setRowModesModel(newRowModesModel);
+  };
+
+  const handleSnackbarClose = (
+    event?: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setSnackbar(null);
+  };
+
+  const handleRowEditStart = (
+    params: GridRowParams,
+    event: MuiEvent<React.SyntheticEvent>
+  ) => {
+    event.defaultMuiPrevented = true;
+  };
+
+  const handleRowEditStop: GridEventListener<"rowEditStop"> = (
+    params,
+    event
+  ) => {
+    event.defaultMuiPrevented = true;
+  };
+
+  const processRowUpdate = (
+    newRow: IProductVariantPriceTable,
+    oldRow: IProductVariantPriceTable
+  ) => {
+    const updatedRow = { ...newRow, isNew: false };
+    setRows(rows.map((row) => (row.id === newRow.id ? updatedRow : row)));
+    setUpdateMainState(true);
+    return updatedRow;
+  };
+
   return (
     <EditorCard>
       <CollapsableContentWithTitle title="Prices">
@@ -24,9 +175,29 @@ const ProductVariantPricesEditor = ({
             first save.
           </Typography>
         ) : (
-          <Typography variant="body1" color="textSecondary">
-            Add product variant prices here.
-          </Typography>
+          <>
+            <Typography variant="body1" color="textSecondary">
+              Matrix of prices for each product variant. You can edit the prices
+              directly in the table.
+            </Typography>
+            <DataGrid
+              rows={rows}
+              columns={columns}
+              density={"compact"}
+              editMode={"cell"}
+              hideFooter={true}
+              autoHeight={true}
+              rowModesModel={rowModesModel}
+              onRowModesModelChange={handleRowModesModelChange}
+              onRowEditStart={handleRowEditStart}
+              onRowEditStop={handleRowEditStop}
+              processRowUpdate={processRowUpdate}
+              slotProps={{
+                toolbar: { setRows, setRowModesModel },
+              }}
+              sx={{ overflowX: "scroll" }}
+            />
+          </>
         )}
       </CollapsableContentWithTitle>
     </EditorCard>

--- a/src/dashboard/components/Dashboard/Catalog/Products/Editor/ProductEditorWrapper.tsx
+++ b/src/dashboard/components/Dashboard/Catalog/Products/Editor/ProductEditorWrapper.tsx
@@ -249,6 +249,7 @@ const ProductEditorWrapper = ({
             disabled={false}
             state={productState}
             dispatch={dispatchProductState}
+            pricelistsData={pricelistsData}
           />
         </Grid>
         <Grid item md={4} xs={12}>

--- a/src/dashboard/utils/productSerializer.ts
+++ b/src/dashboard/utils/productSerializer.ts
@@ -1,0 +1,75 @@
+import { IPriceList } from "@/types/localization";
+import { IAttributeType, IBaseAttributes } from "@/types/product";
+
+/** Price */
+
+export const deserializeProductVariantPricesToRow = (
+  row: any,
+  pricelistsData: IPriceList[]
+) => {
+  // since prices are initialy stored as an array of objects that the backend expects, where expected format is { pricelist: number, price: number }
+  if (!row?.price) return {};
+  let prices: any = {};
+  pricelistsData?.forEach((pricelist: IPriceList) => {
+    prices[`$PRICE_${pricelist.code}`] = row.price.find(
+      (price: any) => price.price_list === pricelist.code
+    )?.price;
+  });
+
+  return prices;
+};
+
+export const serializeProductVariantPricesFromRow = (
+  row: any,
+  pricelistsData: IPriceList[]
+) => {
+  // since prices in the row are stored as $PRICE_... we need to filter them out and serialize them
+  // into an array of objects that the backend expects, where expected format is { pricelist: number, price: number }
+  if (!row) return [];
+  const prices = Object.entries(row)
+    .filter(([key, value]) => key.startsWith("$PRICE_") && value)
+    .map(([key, value]) => ({
+      price_list: pricelistsData?.find(
+        (pricelist) => pricelist.code === key.replace("$PRICE_", "")
+      )?.code,
+      price: Number(value),
+    }));
+
+  return prices;
+};
+
+/** Attributes */
+
+export const deserializeProductVariantAttributesToRow = (
+  row: any,
+  attributesData: IAttributeType[]
+) => {
+  // since attributes are initialy stored as an array of numbers (attribute ids) we need to firstly
+  // create an object with keys $ATTRIBUTE_... and then assign value to them (item from the array that is also in the base_attributes array (as id))
+  if (!row?.attributes) return {};
+  let attributes: any = {};
+  attributesData?.forEach((attribute: IAttributeType) => {
+    attributes[`$ATTRIBUTE_${attribute.type_name}`] = attribute.base_attributes
+      .map((baseAttribute: IBaseAttributes) => baseAttribute.id)
+      ?.find(
+        (id: number) =>
+          id ===
+          row.attributes.find((attributeId: number) => attributeId === id)
+      );
+  });
+  return attributes;
+};
+
+export const serializeProductVariantAttributesFromRow = (
+  row: any,
+  attributesData: IAttributeType[]
+) => {
+  // since attributes in the row are stored as $ATTRIBUTE_... we need to filter them out and serialize them
+  // into an array of numbers (attribute ids) that the backend expects
+  if (!row) return [];
+  const attributes = Object.entries(row)
+    .filter(([key, value]) => key.startsWith("$ATTRIBUTE_") && value)
+    .map(([key, value]) => value);
+
+  return attributes;
+};


### PR DESCRIPTION
closes #112 

Added interactive product price editor (matrix). It's more convenient than editing directly in the `variants` editor (we can probably remove `Prices` from `Variants` editor (or move it to the end).
When you update `Prices` it automatically updates `Variants` and vice versa. 😜 

![Snímek obrazovky 2023-03-22 v 14 36 07](https://user-images.githubusercontent.com/34132752/226921284-155a7266-016d-48d5-9c17-96745d580016.png)
