### PR TITLE
T-148: Product Translated SEO Fields

### DIFF
--- a/src/dashboard/components/Dashboard/Catalog/Products/Editor/Product/ProductTranslatedFields.tsx
+++ b/src/dashboard/components/Dashboard/Catalog/Products/Editor/Product/ProductTranslatedFields.tsx
@@ -10,12 +10,7 @@ import EditorCard from "@/components/Dashboard/Generic/EditorCard";
 import CollapsableContentWithTitle from "@/components/Dashboard/Generic/CollapsableContentWithTitle";
 // mui
 import Box from "@mui/material/Box";
-import Card from "@mui/material/Card";
-import Typography from "@mui/material/Typography";
-import InputLabel from "@mui/material/InputLabel";
-import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
-import Select, { SelectChangeEvent } from "@mui/material/Select";
 import TextField from "@mui/material/TextField";
 import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
@@ -58,7 +53,6 @@ const ProductTranslatedFields = ({
   // const [title, setTitle] = useState<string>("");
   // const [slug, setSlug] = useState<string>("");
   const [editSlug, setEditSlug] = useState<boolean>(false);
-  const [description, setDescription] = useState<string>("");
 
   useEffect(() => {
     if (!editSlug && state?.title != undefined) {
@@ -96,6 +90,20 @@ const ProductTranslatedFields = ({
           language,
           data: {
             slug: slug,
+          },
+        },
+      },
+    });
+  };
+
+  const setShortDescription = (text: string) => {
+    dispatch({
+      type: ActionSetProduct.SETTRANSLATION,
+      payload: {
+        translation: {
+          language,
+          data: {
+            short_description: text,
           },
         },
       },
@@ -161,6 +169,16 @@ const ProductTranslatedFields = ({
                 </IconButton>
               </InputAdornment>
             ),
+          }}
+        />
+        <TextField
+          label="Short description"
+          value={state?.short_description || ""}
+          multiline
+          onChange={(
+            e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+          ) => {
+            setShortDescription(e.target.value);
           }}
         />
         <EditorJSField

--- a/src/dashboard/components/Dashboard/Catalog/Products/Editor/Product/ProductTranslatedSEOFields.tsx
+++ b/src/dashboard/components/Dashboard/Catalog/Products/Editor/Product/ProductTranslatedSEOFields.tsx
@@ -1,0 +1,160 @@
+// next.js
+// react
+import { useEffect, useState } from "react";
+// libs
+import useSWRImmutable from "swr/immutable";
+
+// components
+import EditorCard from "@/components/Dashboard/Generic/EditorCard";
+import CollapsableContentWithTitle from "@/components/Dashboard/Generic/CollapsableContentWithTitle";
+// mui
+import Box from "@mui/material/Box";
+import FormControl from "@mui/material/FormControl";
+import TextField from "@mui/material/TextField";
+import Stack from "@mui/material/Stack";
+import Tab from "@mui/material/Tab";
+import TabContext from "@mui/lab/TabContext";
+import TabList from "@mui/lab/TabList";
+import TabPanel from "@mui/lab/TabPanel";
+import {
+  ActionSetProduct,
+  IProductTranslation,
+  ISetProductStateData,
+} from "@/types/product";
+import { ISetProductStateAction } from "../ProductEditorWrapper";
+import { ILanguage } from "@/types/localization";
+
+interface IProductTranslatedSEOFieldsProps {
+  language: string;
+  state: IProductTranslation;
+  dispatch: React.Dispatch<ISetProductStateAction>;
+}
+const ProductTranslatedFields = ({
+  language,
+  state,
+  dispatch,
+}: IProductTranslatedSEOFieldsProps) => {
+  const setMetaTitle = (title: string) => {
+    dispatch({
+      type: ActionSetProduct.SETTRANSLATION,
+      payload: {
+        translation: {
+          language,
+          data: {
+            meta_title: title,
+          },
+        },
+      },
+    });
+  };
+
+  const setMetaDescription = (text: string) => {
+    dispatch({
+      type: ActionSetProduct.SETTRANSLATION,
+      payload: {
+        translation: {
+          language,
+          data: {
+            meta_description: text,
+          },
+        },
+      },
+    });
+  };
+
+  return (
+    <FormControl fullWidth margin={"normal"}>
+      <Stack spacing={2}>
+        <TextField
+          label="Meta title"
+          value={state?.meta_title || ""}
+          onChange={(
+            e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+          ) => {
+            setMetaTitle(e.target.value);
+          }}
+        />
+        <TextField
+          label="Meta description"
+          value={state?.meta_description || ""}
+          multiline
+          onChange={(
+            e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+          ) => {
+            setMetaDescription(e.target.value);
+          }}
+        />
+      </Stack>
+    </FormControl>
+  );
+};
+
+interface IProductTranslatedSEOFieldsWrapperProps {
+  state: ISetProductStateData;
+  dispatch: React.Dispatch<ISetProductStateAction>;
+}
+
+const ProductTranslatedSEOFieldsWrapper = ({
+  state,
+  dispatch,
+}: IProductTranslatedSEOFieldsWrapperProps) => {
+  const { data: languages } = useSWRImmutable<ILanguage[]>(
+    "/country/languages/"
+  );
+
+  const [language, setLanguage] = useState<string>("");
+
+  const handleLanguageChange = (
+    event: React.SyntheticEvent,
+    newValue: string
+  ) => {
+    setLanguage(newValue);
+  };
+
+  useEffect(() => {
+    setLanguage(languages?.find((language) => language.default)?.code || "");
+  }, [languages]);
+
+  return (
+    <EditorCard>
+      <CollapsableContentWithTitle defaultOpen={false} title="SEO">
+        <Box>
+          <TabContext value={language}>
+            <Box>
+              <TabList
+                onChange={handleLanguageChange}
+                aria-label="lab API tabs example"
+              >
+                {languages?.map((language) => (
+                  <Tab
+                    key={language.code}
+                    label={language.code.toUpperCase()}
+                    value={language.code}
+                  />
+                ))}
+              </TabList>
+            </Box>
+            {languages?.map((language) => (
+              <TabPanel
+                sx={{ padding: 0 }}
+                key={language.code}
+                value={language.code}
+              >
+                <ProductTranslatedFields
+                  language={language.code}
+                  state={
+                    state?.translations
+                      ? state?.translations[language.code]
+                      : ({} as IProductTranslation)
+                  }
+                  dispatch={dispatch}
+                />
+              </TabPanel>
+            ))}
+          </TabContext>
+        </Box>
+      </CollapsableContentWithTitle>
+    </EditorCard>
+  );
+};
+export default ProductTranslatedSEOFieldsWrapper;

--- a/src/dashboard/components/Dashboard/Catalog/Products/Editor/ProductEditorWrapper.tsx
+++ b/src/dashboard/components/Dashboard/Catalog/Products/Editor/ProductEditorWrapper.tsx
@@ -36,6 +36,7 @@ import {
 import { postProduct, putProduct } from "@/api/country/product/product";
 import { IPriceList } from "@/types/localization";
 import ProductTypeSelect from "./Product/ProductTypeSelect";
+import ProductTranslatedSEOFieldsWrapper from "./Product/ProductTranslatedSEOFields";
 
 export interface ISetProductStateAction {
   type: ActionSetProduct;
@@ -250,6 +251,10 @@ const ProductEditorWrapper = ({
       <Grid container spacing={2}>
         <Grid item md={8} xs={12}>
           <ProductTranslatedFieldsWrapper
+            state={productState}
+            dispatch={dispatchProductState}
+          />
+          <ProductTranslatedSEOFieldsWrapper
             state={productState}
             dispatch={dispatchProductState}
           />

--- a/src/dashboard/components/Dashboard/Generic/CollapsableContentWithTitle.tsx
+++ b/src/dashboard/components/Dashboard/Generic/CollapsableContentWithTitle.tsx
@@ -11,6 +11,7 @@ import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 interface ICollapsableContentWithTitleProps {
   title: string;
   children: React.ReactNode;
+  defaultOpen?: boolean;
 }
 
 /**
@@ -22,8 +23,9 @@ interface ICollapsableContentWithTitleProps {
 const CollapsableContentWithTitle = ({
   title,
   children,
+  defaultOpen = true,
 }: ICollapsableContentWithTitleProps) => {
-  const [open, setOpen] = useState<boolean>(true);
+  const [open, setOpen] = useState<boolean>(defaultOpen);
 
   return (
     <>


### PR DESCRIPTION
👋 

little (and maybe one of last?) addition to product edit page. It's SEO (meta title & description) fields 
It's in separate toggle component so that list of translated fields doesn't get too long (title, slug, short description and description).

Thanks!  
![Snímek obrazovky 2023-04-18 v 15 59 02](https://user-images.githubusercontent.com/34132752/232800804-df7fdc62-7789-4cfd-b33b-c9cb26488f70.png)
