### PR TITLE
#T-178: UserContext provider + API Routes + new Axios interceptor

### DIFF
--- a/src/dashboard/api/users-roles/user.ts
+++ b/src/dashboard/api/users-roles/user.ts
@@ -1,0 +1,10 @@
+import { axiosPrivate } from "@/utils/axiosPrivate";
+
+export const getUser = async () => {
+  // Get user data
+  // URL: /user
+  // Method: GET
+  // Params: email
+  // Return: Promise
+  return await axiosPrivate.get(`/user`);
+};

--- a/src/dashboard/components/Dashboard/Nav.tsx
+++ b/src/dashboard/components/Dashboard/Nav.tsx
@@ -16,6 +16,7 @@ import Navigation from "./Navigation/Navigation";
 import Logo from "../Logo";
 import Scrollbar from "./Navigation/Scrollbar";
 import { useUser } from "@/utils/context/user";
+import { IGroup } from "@/types/user";
 
 const NAV_WIDTH = 280;
 
@@ -34,7 +35,7 @@ interface IDashboardNavProps {
 const DashboardNav = ({ openNav, onCloseNav }: IDashboardNavProps) => {
   const { pathname } = useRouter();
 
-  const { user } = useUser();
+  const { user, roles } = useUser();
 
   const isDesktop = useResponsive("up", "lg", "lg");
 
@@ -72,7 +73,7 @@ const DashboardNav = ({ openNav, onCloseNav }: IDashboardNavProps) => {
             </Typography>
 
             <Typography variant="body2" sx={{ color: "text.secondary" }}>
-              Editor, Sales
+              {roles?.map((role: IGroup) => role.name).join(", ")}
             </Typography>
           </Box>
         </StyledAccount>

--- a/src/dashboard/components/Dashboard/Nav.tsx
+++ b/src/dashboard/components/Dashboard/Nav.tsx
@@ -15,6 +15,7 @@ import navigationData from "../../utils/navigationData";
 import Navigation from "./Navigation/Navigation";
 import Logo from "../Logo";
 import Scrollbar from "./Navigation/Scrollbar";
+import { useUser } from "@/utils/context/user";
 
 const NAV_WIDTH = 280;
 
@@ -32,6 +33,8 @@ interface IDashboardNavProps {
 }
 const DashboardNav = ({ openNav, onCloseNav }: IDashboardNavProps) => {
   const { pathname } = useRouter();
+
+  const { user } = useUser();
 
   const isDesktop = useResponsive("up", "lg", "lg");
 
@@ -65,7 +68,7 @@ const DashboardNav = ({ openNav, onCloseNav }: IDashboardNavProps) => {
           <AccountCircleIcon />
           <Box sx={{ ml: 2 }}>
             <Typography variant="subtitle2" sx={{ color: "text.primary" }}>
-              John Doe
+              {user?.email}
             </Typography>
 
             <Typography variant="body2" sx={{ color: "text.secondary" }}>

--- a/src/dashboard/package-lock.json
+++ b/src/dashboard/package-lock.json
@@ -35,11 +35,12 @@
         "@types/react-dom": "18.0.9",
         "apexcharts": "^3.37.2",
         "axios": "^1.3.4",
+        "cookies-next": "^2.1.1",
         "editorjs-inline-tool": "^0.4.0",
         "eslint": "8.27.0",
         "eslint-config-next": "13.0.3",
         "immutability-helper": "^3.1.1",
-        "js-cookie": "^3.0.1",
+        "js-cookie": "^3.0.5",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
         "mem": "^9.0.2",
@@ -56,6 +57,7 @@
       },
       "devDependencies": {
         "@editorjs/image": "^2.8.1",
+        "@types/js-cookie": "^3.0.3",
         "eslint-config-prettier": "^8.5.0",
         "prettier": "2.7.1",
         "sass": "^1.58.3"
@@ -1665,9 +1667,20 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
     "node_modules/@types/format-util": {
       "version": "1.0.2",
       "license": "MIT"
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.3.tgz",
+      "integrity": "sha512-Xe7IImK09HP1sv2M/aI+48a20VX+TdRJucfq4vfRVy6nWN8PYPOEnlMRSgxJAgYQIXJVL8dZ4/ilAM7dWNaOww==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -2368,6 +2381,29 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookies-next": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cookies-next/-/cookies-next-2.1.1.tgz",
+      "integrity": "sha512-AZGZPdL1hU3jCjN2UMJTGhLOYzNUN9Gm+v8BdptYIHUdwz397Et1p+sZRfvAl8pKnnmMdX2Pk9xDRKCGBum6GA==",
+      "dependencies": {
+        "@types/cookie": "^0.4.1",
+        "@types/node": "^16.10.2",
+        "cookie": "^0.4.0"
+      }
+    },
+    "node_modules/cookies-next/node_modules/@types/node": {
+      "version": "16.18.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA=="
     },
     "node_modules/core-js-pure": {
       "version": "3.26.1",
@@ -3727,10 +3763,11 @@
       "license": "ISC"
     },
     "node_modules/js-cookie": {
-      "version": "3.0.1",
-      "license": "MIT",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/js-sdsl": {
@@ -6370,8 +6407,19 @@
         "tslib": "^2.4.0"
       }
     },
+    "@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
     "@types/format-util": {
       "version": "1.0.2"
+    },
+    "@types/js-cookie": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.3.tgz",
+      "integrity": "sha512-Xe7IImK09HP1sv2M/aI+48a20VX+TdRJucfq4vfRVy6nWN8PYPOEnlMRSgxJAgYQIXJVL8dZ4/ilAM7dWNaOww==",
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.29"
@@ -6788,6 +6836,28 @@
     },
     "convert-source-map": {
       "version": "1.9.0"
+    },
+    "cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+    },
+    "cookies-next": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cookies-next/-/cookies-next-2.1.1.tgz",
+      "integrity": "sha512-AZGZPdL1hU3jCjN2UMJTGhLOYzNUN9Gm+v8BdptYIHUdwz397Et1p+sZRfvAl8pKnnmMdX2Pk9xDRKCGBum6GA==",
+      "requires": {
+        "@types/cookie": "^0.4.1",
+        "@types/node": "^16.10.2",
+        "cookie": "^0.4.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.18.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+          "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA=="
+        }
+      }
     },
     "core-js-pure": {
       "version": "3.26.1"
@@ -7625,7 +7695,9 @@
       "version": "2.0.0"
     },
     "js-cookie": {
-      "version": "3.0.1"
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="
     },
     "js-sdsl": {
       "version": "4.1.5"

--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -37,11 +37,12 @@
     "@types/react-dom": "18.0.9",
     "apexcharts": "^3.37.2",
     "axios": "^1.3.4",
+    "cookies-next": "^2.1.1",
     "editorjs-inline-tool": "^0.4.0",
     "eslint": "8.27.0",
     "eslint-config-next": "13.0.3",
     "immutability-helper": "^3.1.1",
-    "js-cookie": "^3.0.1",
+    "js-cookie": "^3.0.5",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
     "mem": "^9.0.2",
@@ -58,6 +59,7 @@
   },
   "devDependencies": {
     "@editorjs/image": "^2.8.1",
+    "@types/js-cookie": "^3.0.3",
     "eslint-config-prettier": "^8.5.0",
     "prettier": "2.7.1",
     "sass": "^1.58.3"

--- a/src/dashboard/pages/_app.tsx
+++ b/src/dashboard/pages/_app.tsx
@@ -10,6 +10,7 @@ import { axiosPrivate } from "@/utils/axiosPrivate";
 import { useRouter } from "next/router";
 import fetcher from "@/api/fetcher";
 import axiosFetcher from "@/api/fetcher";
+import { UserProvider } from "@/utils/context/user";
 
 const montserrat = Montserrat({
   weight: ["400", "500", "700"],
@@ -90,7 +91,9 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
                 .catch((err: any) => console.log("fetcher err")),
           }}
         >
-          <Component {...pageProps} />
+          <UserProvider>
+            <Component {...pageProps} />
+          </UserProvider>
         </SWRConfig>
       </main>
     </>

--- a/src/dashboard/pages/api/roles/user/[email].ts
+++ b/src/dashboard/pages/api/roles/user/[email].ts
@@ -1,0 +1,53 @@
+// /api/cart/index.ts
+// call the cart api in the backend
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  api,
+  setRequestResponse,
+  backendApiHelper,
+  cartApiUrlHelper,
+} from "@/utils/interceptors/api";
+import { IUser } from "@/types/user";
+import { HTTPMETHOD } from "@/types/common";
+
+export const userRoleAPI = async (
+  method: HTTPMETHOD,
+  email: string,
+  req?: NextApiRequest,
+  res?: NextApiResponse
+) => {
+  if (req && res) {
+    setRequestResponse(req, res);
+  }
+
+  switch (method) {
+    case "GET":
+      return await api
+        .get(`/roles/user-groups/${email}`)
+        .then((response) => response.data)
+        .then((data: IUser) => {
+          return data;
+        })
+        .catch((error: any) => {
+          throw error;
+        });
+    default:
+      throw new Error("Method not supported");
+  }
+};
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  /**
+   * This is a wrapper for the cart api in the backend
+   * It returns whole cart data from the backend
+   */
+  // get the cart data from the backend
+
+  const { email } = req.query;
+
+  return userRoleAPI("GET", email as string, req, res)
+    .then((data) => res.status(200).json(data))
+    .catch((error) => res.status(400).json(null));
+};
+
+export default handler;

--- a/src/dashboard/pages/api/user/detail/index.ts
+++ b/src/dashboard/pages/api/user/detail/index.ts
@@ -1,0 +1,49 @@
+// /api/cart/index.ts
+// call the cart api in the backend
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  api,
+  setRequestResponse,
+  backendApiHelper,
+  cartApiUrlHelper,
+} from "@/utils/interceptors/api";
+import { IUser } from "@/types/user";
+import { HTTPMETHOD } from "@/types/common";
+
+export const userDetailAPI = async (
+  method: HTTPMETHOD,
+  req?: NextApiRequest,
+  res?: NextApiResponse
+) => {
+  if (req && res) {
+    setRequestResponse(req, res);
+  }
+
+  switch (method) {
+    case "GET":
+      return await api
+        .get("/user/detail")
+        .then((response) => response.data)
+        .then((data: IUser) => {
+          return data;
+        })
+        .catch((error: any) => {
+          throw error;
+        });
+    default:
+      throw new Error("Method not supported");
+  }
+};
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  /**
+   * This is a wrapper for the cart api in the backend
+   * It returns whole cart data from the backend
+   */
+  // get the cart data from the backend
+  return userDetailAPI("GET", req, res)
+    .then((data) => res.status(200).json(data))
+    .catch((error) => res.status(400).json(null));
+};
+
+export default handler;

--- a/src/dashboard/types/common.ts
+++ b/src/dashboard/types/common.ts
@@ -24,3 +24,5 @@ export interface IEntityTranslation {
 export interface IEntityTranslations {
   [locale: string]: IEntityTranslation; // TODO: this needs to be extended according to iso 639 (TLocale)
 }
+
+export type HTTPMETHOD = "GET" | "POST" | "PUT" | "DELETE";

--- a/src/dashboard/utils/context/user.tsx
+++ b/src/dashboard/utils/context/user.tsx
@@ -1,8 +1,9 @@
-import { IPermission, IUser } from "@/types/user";
+import { IGroup, IPermission, IUser } from "@/types/user";
 import { useState, createContext, useContext, useEffect } from "react";
 
 interface IUserContextProps {
   user: IUser | null;
+  roles: IGroup[] | [];
 }
 
 interface IUserProviderProps {
@@ -13,11 +14,15 @@ const UserContext = createContext<Partial<IUserContextProps>>({});
 
 export const UserProvider = ({ children }: IUserProviderProps): JSX.Element => {
   const [user, setUser] = useState<IUser | null>(null);
-  const [permissions, setPermissions] = useState<IPermission[]>([]);
+  const [roles, setRoles] = useState<IGroup[]>([]);
 
   useEffect(() => {
     getUser();
   }, []);
+
+  useEffect(() => {
+    getRoles();
+  }, [user]);
 
   const getUser = async () => {
     await fetch(`/api/user/detail`)
@@ -28,9 +33,20 @@ export const UserProvider = ({ children }: IUserProviderProps): JSX.Element => {
         setUser(null);
       });
   };
+  const getRoles = async () => {
+    if (!user) return;
+    await fetch(`/api/roles/user/${user.email}`)
+      .then((res) => res.json())
+      .then((data) => setRoles(data))
+      .catch((error) => {
+        console.log(error);
+        setRoles([]);
+      });
+  };
 
   const value = {
     user,
+    roles,
   };
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;

--- a/src/dashboard/utils/context/user.tsx
+++ b/src/dashboard/utils/context/user.tsx
@@ -1,0 +1,39 @@
+import { IPermission, IUser } from "@/types/user";
+import { useState, createContext, useContext, useEffect } from "react";
+
+interface IUserContextProps {
+  user: IUser | null;
+}
+
+interface IUserProviderProps {
+  children: React.ReactNode;
+}
+
+const UserContext = createContext<Partial<IUserContextProps>>({});
+
+export const UserProvider = ({ children }: IUserProviderProps): JSX.Element => {
+  const [user, setUser] = useState<IUser | null>(null);
+  const [permissions, setPermissions] = useState<IPermission[]>([]);
+
+  useEffect(() => {
+    getUser();
+  }, []);
+
+  const getUser = async () => {
+    await fetch(`/api/user/detail`)
+      .then((res) => res.json())
+      .then((data) => setUser(data))
+      .catch((error) => {
+        console.log(error);
+        setUser(null);
+      });
+  };
+
+  const value = {
+    user,
+  };
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+};
+
+export const useUser = (): any => useContext(UserContext);

--- a/src/dashboard/utils/interceptors/api.ts
+++ b/src/dashboard/utils/interceptors/api.ts
@@ -10,16 +10,16 @@ const isServer = () => {
   return typeof window === "undefined";
 };
 
-let accessToken = "";
+// let accessToken = "";
 let req = <NextApiRequest>{};
 let res = <NextApiResponse>{};
 const baseURL = process.env.API_URL! || process.env.NEXT_PUBLIC_API_URL!;
 
 export const setAccessToken = (_accessToken: string) => {
-  accessToken = _accessToken;
+  // accessToken = _accessToken;
 };
 
-export const getAccessToken = () => accessToken;
+export const getAccessToken = () => getCookie("accessToken", { req, res });
 
 export const setRequestResponse = (
   _req: NextApiRequest,
@@ -38,6 +38,8 @@ export const api = axios.create({
 });
 
 api.interceptors.request.use((config) => {
+  let accessToken = getAccessToken();
+
   let access = "";
   if (isServer()) {
     access = getCookie("accessToken", { req, res }) as string;

--- a/src/dashboard/utils/interceptors/api.ts
+++ b/src/dashboard/utils/interceptors/api.ts
@@ -1,0 +1,174 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getCookie, deleteCookie, setCookie } from "cookies-next";
+import Cookies from "js-cookie";
+import axios, { AxiosError } from "axios";
+import { GetServerSidePropsContext } from "next";
+import Router from "next/router";
+import jwt_decode from "jwt-decode";
+
+const isServer = () => {
+  return typeof window === "undefined";
+};
+
+let accessToken = "";
+let req = <NextApiRequest>{};
+let res = <NextApiResponse>{};
+const baseURL = process.env.API_URL! || process.env.NEXT_PUBLIC_API_URL!;
+
+export const setAccessToken = (_accessToken: string) => {
+  accessToken = _accessToken;
+};
+
+export const getAccessToken = () => accessToken;
+
+export const setRequestResponse = (
+  _req: NextApiRequest,
+  _res: NextApiResponse
+) => {
+  req = _req;
+  res = _res;
+};
+
+export const api = axios.create({
+  baseURL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+  withCredentials: true, // to send cookie
+});
+
+api.interceptors.request.use((config) => {
+  let access = "";
+  if (isServer()) {
+    access = getCookie("accessToken", { req, res }) as string;
+  } else {
+    access = Cookies.get("accessToken") || "";
+  }
+  if (!accessToken) {
+    setAccessToken(access);
+  }
+  if (accessToken) {
+    config.headers.Authorization = `JWT ${accessToken}`;
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error: AxiosError) => {
+    // check conditions to refresh token
+    if (
+      error.response?.status === 401 &&
+      !error.response?.config?.url?.includes("user/refresh-token") &&
+      !error.response?.config?.url?.includes("user/login")
+    ) {
+      return refreshToken(error);
+    }
+    return Promise.reject(error);
+  }
+);
+
+let fetchingToken = false;
+let subscribers: ((token: string) => any)[] = [];
+
+const onAccessTokenFetched = (token: string) => {
+  subscribers.forEach((callback) => callback(token));
+  subscribers = [];
+};
+
+const addSubscriber = (callback: (token: string) => any) => {
+  subscribers.push(callback);
+};
+
+const refreshToken = async (oError: AxiosError) => {
+  try {
+    const { response } = oError;
+
+    // create new Promise to retry original request
+    const retryOriginalRequest = new Promise((resolve) => {
+      addSubscriber((token: string) => {
+        response!.config.headers["Authorization"] = `JWT ${token}`;
+        resolve(axios(response!.config));
+      });
+    });
+
+    // check whether refreshing token or not
+    if (!fetchingToken) {
+      fetchingToken = true;
+      // refresh token
+      const { data } = await api.post("/user/refresh-token", {
+        refresh: getCookie("refreshToken", { req: req, res: res }),
+      });
+
+      const { access } = data || null;
+      if (access) {
+        setCookie("accessToken", access, {
+          req: req,
+          res: res,
+          expires: new Date((jwt_decode(access) as any).exp * 1000),
+        });
+      }
+
+      // check if this is server or not. We don't wanna save response token on server.
+      if (!isServer) {
+        setAccessToken(access);
+      }
+      // when new token arrives, retry old requests
+      onAccessTokenFetched(access);
+    }
+    return retryOriginalRequest;
+  } catch (error) {
+    // on error go to login page
+    // if (!isServer() && !Router.asPath.includes("/login")) {
+    // 	Router.push("/login");
+    // }
+    // if (isServer()) {
+    // 	res.setHeader("location", "/login");
+    // 	res.statusCode = 302;
+    // 	res.end();
+    // }
+    return Promise.reject(oError);
+  } finally {
+    fetchingToken = false;
+  }
+};
+
+export const cartApiUrlHelper = (
+  url: string,
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
+  // helper function to creaate the url for backend cart api
+  // this is used in pages/api/cart/index.ts
+  // it basically either uses the cart_session cookie or the access token
+  // access token is preferred over cart_session
+  // if there is no access token, then we use the cart_session cookie
+
+  //   const cart_session = getCookie("cart_session", { req, res });
+  const access_token = getCookie("accessToken", { req, res });
+
+  if (access_token) {
+    return url;
+  }
+  //   if (cart_session) {
+  //     return `${url}?cart_session=${cart_session}`;
+  //   }
+  return url;
+};
+
+export const backendApiHelper = (req: NextApiRequest, res: NextApiResponse) => {
+  // handle locale as well!
+
+  let headers: any = {
+    "Content-Type": "application/json",
+    // ...req.headers,
+  };
+
+  const access_token = getCookie("accessToken", { req, res });
+  if (access_token) {
+    headers["Authorization"] = `JWT ${access_token}`;
+  }
+  return headers;
+};


### PR DESCRIPTION
Main goal of this branch was to create UserContext provider which should help us to inject "global" user data into child components (everything below `_app.tsx `).
But that brought some issues mainly due to security of fetching user data directly from backend. So after some time we (with @lakatop ) settled on using next [Next API routes](https://nextjs.org/docs/api-routes/introduction). Which could help us with protecting or `core` from client-side requests. We can implement our API method iteratively into this Next API wrapper, but I'd vote for doing it. 
This also brought up a slight need for redoing our axios interceptor. It was fully reimplemented into `/utils/interceptors/api`. This interceptor is ready to be used on the server-side of our Next app.

And as a bonus with example of using the UserContext provider, left side navbar is now filled with data :) using our `useUser` hook.
<img width="372" alt="Snímek obrazovky 2023-04-27 v 17 40 43" src="https://user-images.githubusercontent.com/34132752/234914462-6fb7e7c6-c043-4b50-94f9-f79281a87ba0.png">


We will have to implement also middleware that kicks out users with invalid/null access/refresh token. However, I'd do it in different branch.

I'm marking this as a draft and please let me know what do you think about this (since it's quite large switch).


