### PR TITLE
T-57 Category API storefront

### DIFF
--- a/src/backend/core/category/serializers.py
+++ b/src/backend/core/category/serializers.py
@@ -2,7 +2,6 @@ from parler_rest.serializers import (
     TranslatableModelSerializer,
     TranslatedFieldsField,
 )
-from rest_framework.relations import PrimaryKeyRelatedField
 from rest_framework.serializers import (
     ModelSerializer,
 )

--- a/src/backend/core/category/serializers.py
+++ b/src/backend/core/category/serializers.py
@@ -57,19 +57,18 @@ class CategoryRecursiveStorefrontSerializer(TranslatedSerializerMixin, ModelSeri
         )
 
 
-class CategoryDetailStorefrontSerializer(TranslatableModelSerializer, ModelSerializer):
+class CategoryDetailStorefrontSerializer(CategoryRecursiveStorefrontSerializer):
     """
     Serializer returning detailed data about category for storefront.
-    Language specific data are present in all languages (in `translations` field).
+    Only one translation is returned (see TranslatedSerializerMixin)
     """
-
-    translations = TranslatedFieldsField(shared_model=Category)
-
-    # children = PrimaryKeyRelatedField(many=True, required=False, source="published_children")
 
     class Meta:
         model = Category
-        fields = ("id", "translations", "parent")
+        fields = CategoryRecursiveStorefrontSerializer.Meta.fields + (
+            "description",
+            "meta_description",
+        )
 
 
 class CategoryRecursiveDashboardSerializer(CategoryRecursiveStorefrontSerializer):
@@ -98,6 +97,7 @@ class CategoryDetailDashboardSerializer(TranslatableModelSerializer, ModelSerial
     class Meta:
         model = Category
         fields = ("id", "published", "translations", "update_at", "create_at", "parent")
+
 
 # class CategoryWithChildrenSerializer(TranslatedSerializerMixin, ModelSerializer):
 #     """

--- a/src/backend/core/category/serializers.py
+++ b/src/backend/core/category/serializers.py
@@ -1,17 +1,18 @@
-from rest_framework_recursive.fields import RecursiveField
-from core.mixins import (
-    TranslatedSerializerMixin,
-)
-from rest_framework.serializers import (
-    ModelSerializer,
-    SerializerMethodField,
-)
-from category.models import (
-    Category,
-)
 from parler_rest.serializers import (
     TranslatableModelSerializer,
     TranslatedFieldsField,
+)
+from rest_framework.relations import PrimaryKeyRelatedField
+from rest_framework.serializers import (
+    ModelSerializer,
+)
+from rest_framework_recursive.fields import RecursiveField
+
+from category.models import (
+    Category,
+)
+from core.mixins import (
+    TranslatedSerializerMixin,
 )
 
 
@@ -37,9 +38,10 @@ class CategorySerializer(TranslatedSerializerMixin, ModelSerializer):
         )
 
 
-class CategoryRecoursiveSerializer(CategorySerializer):
+class CategoryRecursiveStorefrontSerializer(TranslatedSerializerMixin, ModelSerializer):
     """
-    Extension of CategorySerializer with children field.
+    Serializes categories into tree structure for storefront.
+    Only one translation is returned (see TranslatedSerializerMixin)
     """
 
     children = RecursiveField(many=True, required=False, source="all_children")
@@ -48,19 +50,45 @@ class CategoryRecoursiveSerializer(CategorySerializer):
         model = Category
         fields = (
             "id",
-            "published",
             "title",
             "meta_title",
             "slug",
-            "create_at",
-            "update_at",
             "children",
         )
 
 
-class CategoryDetailSerializer(TranslatableModelSerializer, ModelSerializer):
+class CategoryDetailStorefrontSerializer(TranslatableModelSerializer, ModelSerializer):
     """
-    Serializer for category detail.
+    Serializer returning detailed data about category for storefront.
+    Language specific data are present in all languages (in `translations` field).
+    """
+
+    translations = TranslatedFieldsField(shared_model=Category)
+    children = PrimaryKeyRelatedField(many=True, required=False, source="published_children")
+
+    class Meta:
+        model = Category
+        fields = ("id", "translations", "parent", "children")
+
+
+class CategoryRecursiveDashboardSerializer(CategoryRecursiveStorefrontSerializer):
+    """
+    Serializes categories into tree structure for dashboard.
+    Only one translation is returned (see TranslatedSerializerMixin)
+    """
+
+    class Meta(CategoryRecursiveStorefrontSerializer.Meta):
+        model = Category
+        fields = CategoryRecursiveStorefrontSerializer.Meta.fields + (
+            "published",
+            "create_at",
+            "update_at",
+        )
+
+
+class CategoryDetailDashboardSerializer(TranslatableModelSerializer, ModelSerializer):
+    """
+    Serializer returning detailed data about category for dashboard.
     Language specific data are present in all languages (in `translations` field).
     """
 
@@ -70,28 +98,27 @@ class CategoryDetailSerializer(TranslatableModelSerializer, ModelSerializer):
         model = Category
         fields = ("id", "published", "translations", "update_at", "create_at", "parent")
 
-
-class CategoryWithChildrenSerializer(TranslatedSerializerMixin, ModelSerializer):
-    """
-    Extension of CategoryDetailSerializer with children field.
-    """
-
-    children = SerializerMethodField()
-
-    class Meta:
-        model = Category
-        fields = (
-            "id",
-            "title",
-            "description",
-            "meta_title",
-            "meta_description",
-            "slug",
-            "parent",
-            "children",
-        )
-
-    def get_children(self, obj):
-        return [
-            CategoryDetailSerializer(child).data for child in obj.published_children
-        ]
+# class CategoryWithChildrenSerializer(TranslatedSerializerMixin, ModelSerializer):
+#     """
+#     Extension of CategoryDetailSerializer with children field.
+#     """
+#
+#     children = SerializerMethodField()
+#
+#     class Meta:
+#         model = Category
+#         fields = (
+#             "id",
+#             "title",
+#             "description",
+#             "meta_title",
+#             "meta_description",
+#             "slug",
+#             "parent",
+#             "children",
+#         )
+#
+#     def get_children(self, obj):
+#         return [
+#             CategoryDetailSerializer(child).data for child in obj.published_children
+#         ]

--- a/src/backend/core/category/serializers.py
+++ b/src/backend/core/category/serializers.py
@@ -104,7 +104,6 @@ class CategoryDetailDashboardSerializer(TranslatableModelSerializer, ModelSerial
         model = Category
         fields = ("id", "published", "translations", "update_at", "create_at", "parent")
 
-
 # class CategoryWithChildrenSerializer(TranslatedSerializerMixin, ModelSerializer):
 #     """
 #     Extension of CategoryDetailSerializer with children field.

--- a/src/backend/core/category/serializers.py
+++ b/src/backend/core/category/serializers.py
@@ -104,6 +104,7 @@ class CategoryDetailDashboardSerializer(TranslatableModelSerializer, ModelSerial
         model = Category
         fields = ("id", "published", "translations", "update_at", "create_at", "parent")
 
+
 # class CategoryWithChildrenSerializer(TranslatedSerializerMixin, ModelSerializer):
 #     """
 #     Extension of CategoryDetailSerializer with children field.

--- a/src/backend/core/category/serializers.py
+++ b/src/backend/core/category/serializers.py
@@ -71,7 +71,7 @@ class CategoryDetailSerializer(TranslatableModelSerializer, ModelSerializer):
         fields = ("id", "published", "translations", "update_at", "create_at", "parent")
 
 
-class CategoryWithChildrenSerializer(CategoryDetailSerializer):
+class CategoryWithChildrenSerializer(TranslatedSerializerMixin, ModelSerializer):
     """
     Extension of CategoryDetailSerializer with children field.
     """
@@ -82,10 +82,11 @@ class CategoryWithChildrenSerializer(CategoryDetailSerializer):
         model = Category
         fields = (
             "id",
-            "published",
-            "translations",
-            "update_at",
-            "create_at",
+            "title",
+            "description",
+            "meta_title",
+            "meta_description",
+            "slug",
             "parent",
             "children",
         )

--- a/src/backend/core/category/serializers.py
+++ b/src/backend/core/category/serializers.py
@@ -44,7 +44,7 @@ class CategoryRecursiveStorefrontSerializer(TranslatedSerializerMixin, ModelSeri
     Only one translation is returned (see TranslatedSerializerMixin)
     """
 
-    children = RecursiveField(many=True, required=False, source="all_children")
+    children = RecursiveField(many=True, required=False, source="published_children")
 
     class Meta:
         model = Category
@@ -63,7 +63,7 @@ class CategoryDetailStorefrontSerializer(CategoryRecursiveStorefrontSerializer):
     Only one translation is returned (see TranslatedSerializerMixin)
     """
 
-    class Meta:
+    class Meta(CategoryRecursiveStorefrontSerializer.Meta):
         model = Category
         fields = CategoryRecursiveStorefrontSerializer.Meta.fields + (
             "description",
@@ -71,15 +71,22 @@ class CategoryDetailStorefrontSerializer(CategoryRecursiveStorefrontSerializer):
         )
 
 
-class CategoryRecursiveDashboardSerializer(CategoryRecursiveStorefrontSerializer):
+class CategoryRecursiveDashboardSerializer(TranslatedSerializerMixin, ModelSerializer):
     """
     Serializes categories into tree structure for dashboard.
     Only one translation is returned (see TranslatedSerializerMixin)
     """
 
-    class Meta(CategoryRecursiveStorefrontSerializer.Meta):
+    children = RecursiveField(many=True, required=False, source="all_children")
+
+    class Meta:
         model = Category
-        fields = CategoryRecursiveStorefrontSerializer.Meta.fields + (
+        fields = (
+            "id",
+            "title",
+            "meta_title",
+            "slug",
+            "children",
             "published",
             "create_at",
             "update_at",

--- a/src/backend/core/category/serializers.py
+++ b/src/backend/core/category/serializers.py
@@ -64,11 +64,12 @@ class CategoryDetailStorefrontSerializer(TranslatableModelSerializer, ModelSeria
     """
 
     translations = TranslatedFieldsField(shared_model=Category)
-    children = PrimaryKeyRelatedField(many=True, required=False, source="published_children")
+
+    # children = PrimaryKeyRelatedField(many=True, required=False, source="published_children")
 
     class Meta:
         model = Category
-        fields = ("id", "translations", "parent", "children")
+        fields = ("id", "translations", "parent")
 
 
 class CategoryRecursiveDashboardSerializer(CategoryRecursiveStorefrontSerializer):

--- a/src/backend/core/category/urls.py
+++ b/src/backend/core/category/urls.py
@@ -1,11 +1,10 @@
 from . import views
 from django.urls import path
 
-
 urlpatterns = [
-    path("dashboard/", views.CategoryViewDashboard().as_view()),
-    path("dashboard/<int:pk>/", views.CategoryDetailViewDashboard.as_view()),
-    path("storefront/<int:pk>/", views.CategoryTopLevelViewStorefront.as_view()),
-    path("storefront/top-level/", views.CategoryTopLevelViewStorefront.as_view()),
-    path("dashboard/<int:id>/children/", views.CategoryChildrenViewDashboard.as_view()),
+    path("dashboard/", views.CategoryDashboardView.as_view()),
+    path("dashboard/<int:pk>/", views.CategoryDetailDashboardView.as_view()),
+    path("storefront/", views.CategoryStorefrontView.as_view()),
+    path("storefront/<int:pk>/", views.CategoryDetailStorefrontView.as_view()),
+    # path("dashboard/<int:id>/children/", views.CategoryChildrenViewDashboard.as_view()),
 ]

--- a/src/backend/core/category/urls.py
+++ b/src/backend/core/category/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 
 
 urlpatterns = [
-    path("", views.CategoryViewDashboard().as_view()),
-    path("<int:pk>", views.CategoryDetailViewDashboard.as_view()),
-    path("<int:id>/children", views.CategoryChildrenViewDashboard.as_view()),
+    path("dashboard", views.CategoryViewDashboard().as_view()),
+    path("dashboard/<int:pk>", views.CategoryDetailViewDashboard.as_view()),
+    path("dashboard/<int:id>/children", views.CategoryChildrenViewDashboard.as_view()),
 ]

--- a/src/backend/core/category/urls.py
+++ b/src/backend/core/category/urls.py
@@ -6,6 +6,9 @@ urlpatterns = [
     path("dashboard/<int:pk>/", views.CategoryDetailDashboardView.as_view()),
     path("storefront/", views.CategoryStorefrontView.as_view()),
     path("storefront/<int:pk>/", views.CategoryDetailStorefrontView.as_view()),
-    path("storefront/<int:pk>/products/", views.CategoryDetailStorefrontView.as_view()),
+    path(
+        "storefront/<int:pk>/products/",
+        views.CategoryDetailProductsStorefrontView.as_view(),
+    ),
     # path("dashboard/<int:id>/children/", views.CategoryChildrenViewDashboard.as_view()),
 ]

--- a/src/backend/core/category/urls.py
+++ b/src/backend/core/category/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     path("dashboard/<int:pk>/", views.CategoryDetailDashboardView.as_view()),
     path("storefront/", views.CategoryStorefrontView.as_view()),
     path("storefront/<int:pk>/", views.CategoryDetailStorefrontView.as_view()),
+    path("storefront/<int:pk>/products/", views.CategoryDetailStorefrontView.as_view()),
     # path("dashboard/<int:id>/children/", views.CategoryChildrenViewDashboard.as_view()),
 ]

--- a/src/backend/core/category/urls.py
+++ b/src/backend/core/category/urls.py
@@ -5,5 +5,7 @@ from django.urls import path
 urlpatterns = [
     path("dashboard", views.CategoryViewDashboard().as_view()),
     path("dashboard/<int:pk>", views.CategoryDetailViewDashboard.as_view()),
+    path("storefront/<int:pk>", views.CategoryTopLevelViewStorefront.as_view()),
+    path("storefront/top-level", views.CategoryTopLevelViewStorefront.as_view()),
     path("dashboard/<int:id>/children", views.CategoryChildrenViewDashboard.as_view()),
 ]

--- a/src/backend/core/category/urls.py
+++ b/src/backend/core/category/urls.py
@@ -3,9 +3,9 @@ from django.urls import path
 
 
 urlpatterns = [
-    path("dashboard", views.CategoryViewDashboard().as_view()),
-    path("dashboard/<int:pk>", views.CategoryDetailViewDashboard.as_view()),
-    path("storefront/<int:pk>", views.CategoryTopLevelViewStorefront.as_view()),
-    path("storefront/top-level", views.CategoryTopLevelViewStorefront.as_view()),
-    path("dashboard/<int:id>/children", views.CategoryChildrenViewDashboard.as_view()),
+    path("dashboard/", views.CategoryViewDashboard().as_view()),
+    path("dashboard/<int:pk>/", views.CategoryDetailViewDashboard.as_view()),
+    path("storefront/<int:pk>/", views.CategoryTopLevelViewStorefront.as_view()),
+    path("storefront/top-level/", views.CategoryTopLevelViewStorefront.as_view()),
+    path("dashboard/<int:id>/children/", views.CategoryChildrenViewDashboard.as_view()),
 ]

--- a/src/backend/core/category/views.py
+++ b/src/backend/core/category/views.py
@@ -20,7 +20,7 @@ from category.serializers import (
     CategoryDetailStorefrontSerializer,
 )
 from product.models import Product
-from product.serializers import ProductStorefrontSerializer
+from product.serializers import ProductStorefrontListSerializer
 
 
 @permission_classes([AllowAny])  # TODO: use authentication
@@ -128,7 +128,7 @@ class CategoryDetailProductsStorefrontView(APIView):
             category = Category.objects.get(id=pk, published=True)
             products = _get_all_published_products(category)
 
-            serializer = ProductStorefrontSerializer(
+            serializer = ProductStorefrontListSerializer(
                 products, many=True, context={"request": request}
             )
 

--- a/src/backend/core/category/views.py
+++ b/src/backend/core/category/views.py
@@ -2,7 +2,11 @@ from rest_framework.status import HTTP_201_CREATED, HTTP_400_BAD_REQUEST
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny
-from rest_framework.generics import RetrieveUpdateDestroyAPIView
+from rest_framework.generics import (
+    RetrieveUpdateDestroyAPIView,
+    ListAPIView,
+    RetrieveAPIView,
+)
 
 # from django.contrib.auth.models import User
 from rest_framework.decorators import permission_classes
@@ -61,6 +65,16 @@ class CategoryDetailViewDashboard(RetrieveUpdateDestroyAPIView):
     #     """
     #     instance.published = False
     #     instance.save()
+
+
+@permission_classes([AllowAny])  # TODO: use authentication
+class CategoryTopLevelViewStorefront(ListAPIView):
+    """
+    View for getting category for storefront
+    """
+
+    queryset = Category.objects.filter(published=True, parent=None)
+    serializer_class = CategoryDetailSerializer
 
 
 @permission_classes([AllowAny])  # TODO: use authentication

--- a/src/backend/core/category/views.py
+++ b/src/backend/core/category/views.py
@@ -19,7 +19,7 @@ from category.serializers import (
     CategoryRecursiveStorefrontSerializer,
     CategoryDetailStorefrontSerializer,
 )
-from product.models import Product, ProductVariant, PriceList
+from product.models import Product, PriceList
 from product.serializers import ProductStorefrontListSerializer
 
 

--- a/src/backend/core/category/views.py
+++ b/src/backend/core/category/views.py
@@ -6,7 +6,7 @@ from rest_framework.generics import (
 )
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
-from rest_framework.status import HTTP_201_CREATED, HTTP_400_BAD_REQUEST
+from rest_framework.status import HTTP_201_CREATED, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 from rest_framework.views import APIView
 
 from category.models import Category
@@ -101,17 +101,20 @@ class CategoryDetailStorefrontView(APIView):
         Language-specific data are returned only in the selected language (set in `Accept-Language` header).
         If this header isn't present, Django app language is used instead.
         """
-        category = Category.objects.get(id=pk, published=True)
-        serializer = CategoryDetailStorefrontSerializer(
-            category, context={"request": request}
-        )
-        return Response(serializer.data)
+        try:
+            category = Category.objects.get(id=pk, published=True)
+            serializer = CategoryDetailStorefrontSerializer(
+                category, context={"request": request}
+            )
+            return Response(serializer.data)
+        except Category.DoesNotExist:
+            return Response(status=HTTP_404_NOT_FOUND)
 
 
 @permission_classes([AllowAny])
 class CategoryDetailProductsStorefrontView(APIView):
     """
-    View for all products in given category.
+    View for getting all products in the given category.
     Used for storefront.
     """
 
@@ -126,7 +129,6 @@ class CategoryDetailProductsStorefrontView(APIView):
             category, context={"request": request}
         )
         return Response(serializer.data)
-
 
 # @permission_classes([AllowAny])  # TODO: use authentication
 # class CategoryChildrenViewDashboard(APIView):

--- a/src/backend/core/category/views.py
+++ b/src/backend/core/category/views.py
@@ -1,7 +1,8 @@
 # from django.contrib.auth.models import User
 from rest_framework.decorators import permission_classes
 from rest_framework.generics import (
-    RetrieveUpdateDestroyAPIView, RetrieveAPIView,
+    RetrieveUpdateDestroyAPIView,
+    RetrieveAPIView,
 )
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -11,7 +12,9 @@ from rest_framework.views import APIView
 from category.models import Category
 from category.serializers import (
     CategoryDetailDashboardSerializer,
-    CategoryRecursiveDashboardSerializer, CategoryRecursiveStorefrontSerializer, CategoryDetailStorefrontSerializer,
+    CategoryRecursiveDashboardSerializer,
+    CategoryRecursiveStorefrontSerializer,
+    CategoryDetailStorefrontSerializer,
 )
 
 
@@ -78,11 +81,9 @@ class CategoryStorefrontView(APIView):
         Language-specific data are returned only in the selected language (set in `Accept-Language` header).
         If this header isn't present, Django app language is used instead.
         """
-        categories = Category.objects.filter(
-            parent=None, published=True
-        )
+        root_categories = Category.objects.filter(parent=None, published=True)
         serializer = CategoryRecursiveStorefrontSerializer(
-            categories, many=True, context={"request": request}
+            root_categories, many=True, context={"request": request}
         )
         return Response(serializer.data)
 
@@ -90,7 +91,27 @@ class CategoryStorefrontView(APIView):
 @permission_classes([AllowAny])
 class CategoryDetailStorefrontView(APIView):
     """
-    View for getting categories.
+    View for getting detailed info about a category.
+    Used for storefront.
+    """
+
+    def get(self, request, pk):
+        """
+        Gets detail of the given category.
+        Language-specific data are returned only in the selected language (set in `Accept-Language` header).
+        If this header isn't present, Django app language is used instead.
+        """
+        category = Category.objects.get(id=pk, published=True)
+        serializer = CategoryDetailStorefrontSerializer(
+            category, context={"request": request}
+        )
+        return Response(serializer.data)
+
+
+@permission_classes([AllowAny])
+class CategoryDetailProductsStorefrontView(APIView):
+    """
+    View for all products in given category.
     Used for storefront.
     """
 
@@ -100,13 +121,12 @@ class CategoryDetailStorefrontView(APIView):
         Language-specific data are returned only in the selected language (set in `Accept-Language` header).
         If this header isn't present, Django app language is used instead.
         """
-        category = Category.objects.get(
-            id=pk, published=True
-        )
+        category = Category.objects.get(id=pk, published=True)
         serializer = CategoryDetailStorefrontSerializer(
             category, context={"request": request}
         )
         return Response(serializer.data)
+
 
 # @permission_classes([AllowAny])  # TODO: use authentication
 # class CategoryChildrenViewDashboard(APIView):

--- a/src/backend/core/category/views.py
+++ b/src/backend/core/category/views.py
@@ -152,6 +152,7 @@ def _get_all_published_products(category):
     subcategory_ids = _get_all_subcategory_ids(category)
     return Product.objects.filter(published=True, category__in=subcategory_ids)
 
+
 # @permission_classes([AllowAny])  # TODO: use authentication
 # class CategoryChildrenViewDashboard(APIView):
 #     """

--- a/src/backend/core/category/views.py
+++ b/src/backend/core/category/views.py
@@ -130,12 +130,13 @@ class CategoryDetailProductsStorefrontView(APIView):
             category = Category.objects.get(id=pk, published=True)
             products = _get_all_published_products(category)
 
-            serializer = ProductStorefrontListSerializer(
-                products, many=True, context={"request": request}
-            )
+            pricelist = self._get_pricelist(request)
 
-            pl = self._get_pricelist(request)
-            p = _get_prices(products[0], pl)
+            serializer = ProductStorefrontListSerializer(
+                products,
+                many=True,
+                context={"request": request, "price_list": pricelist},
+            )
 
             return Response(serializer.data)
         except Category.DoesNotExist:

--- a/src/backend/core/category/views.py
+++ b/src/backend/core/category/views.py
@@ -2,11 +2,14 @@
 from rest_framework.decorators import permission_classes
 from rest_framework.generics import (
     RetrieveUpdateDestroyAPIView,
-    RetrieveAPIView,
 )
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
-from rest_framework.status import HTTP_201_CREATED, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
+from rest_framework.status import (
+    HTTP_201_CREATED,
+    HTTP_400_BAD_REQUEST,
+    HTTP_404_NOT_FOUND,
+)
 from rest_framework.views import APIView
 
 from category.models import Category
@@ -16,6 +19,8 @@ from category.serializers import (
     CategoryRecursiveStorefrontSerializer,
     CategoryDetailStorefrontSerializer,
 )
+from product.models import Product
+from product.serializers import ProductStorefrontSerializer
 
 
 @permission_classes([AllowAny])  # TODO: use authentication
@@ -119,16 +124,33 @@ class CategoryDetailProductsStorefrontView(APIView):
     """
 
     def get(self, request, pk):
-        """
-        Gets all published categories for storefront.
-        Language-specific data are returned only in the selected language (set in `Accept-Language` header).
-        If this header isn't present, Django app language is used instead.
-        """
-        category = Category.objects.get(id=pk, published=True)
-        serializer = CategoryDetailStorefrontSerializer(
-            category, context={"request": request}
-        )
-        return Response(serializer.data)
+        try:
+            category = Category.objects.get(id=pk, published=True)
+            products = _get_all_published_products(category)
+
+            serializer = ProductStorefrontSerializer(
+                products, many=True, context={"request": request}
+            )
+
+            return Response(serializer.data)
+        except Category.DoesNotExist:
+            return Response(status=HTTP_404_NOT_FOUND)
+
+
+def _get_all_subcategory_ids(category):
+    """
+    Get IDs of all subcategories (including recursively) under the given category
+    """
+    children = category.published_children
+    return [category.id] + [id for c in children for id in _get_all_subcategory_ids(c)]
+
+
+def _get_all_published_products(category):
+    """
+    Get all published products in the given category
+    """
+    subcategory_ids = _get_all_subcategory_ids(category)
+    return Product.objects.filter(published=True, category__in=subcategory_ids)
 
 # @permission_classes([AllowAny])  # TODO: use authentication
 # class CategoryChildrenViewDashboard(APIView):

--- a/src/backend/core/category/views.py
+++ b/src/backend/core/category/views.py
@@ -88,14 +88,25 @@ class CategoryStorefrontView(APIView):
 
 
 @permission_classes([AllowAny])
-class CategoryDetailStorefrontView(RetrieveAPIView):
+class CategoryDetailStorefrontView(APIView):
     """
     View for getting categories.
     Used for storefront.
     """
 
-    queryset = Category.objects.filter(published=True)
-    serializer_class = CategoryDetailStorefrontSerializer
+    def get(self, request, pk):
+        """
+        Gets all published categories for storefront.
+        Language-specific data are returned only in the selected language (set in `Accept-Language` header).
+        If this header isn't present, Django app language is used instead.
+        """
+        category = Category.objects.get(
+            id=pk, published=True
+        )
+        serializer = CategoryDetailStorefrontSerializer(
+            category, context={"request": request}
+        )
+        return Response(serializer.data)
 
 # @permission_classes([AllowAny])  # TODO: use authentication
 # class CategoryChildrenViewDashboard(APIView):

--- a/src/backend/core/category/views.py
+++ b/src/backend/core/category/views.py
@@ -154,14 +154,6 @@ class CategoryDetailProductsStorefrontView(APIView):
             return PriceList.objects.get(is_default=True)
 
 
-def _get_prices(product, price_list):
-    return [
-        p.formatted_price
-        for v in product.product_variants.all()
-        for p in v.price.filter(price_list=price_list)
-    ]
-
-
 def _get_all_subcategory_ids(category):
     """
     Get IDs of all subcategories (including recursive) under the given category

--- a/src/backend/core/product/serializers.py
+++ b/src/backend/core/product/serializers.py
@@ -516,9 +516,9 @@ class ProductDashboardSerializer(TranslatedSerializerMixin, ModelSerializer):
         )
 
 
-class ProductStorefrontSerializer(TranslatedSerializerMixin, ModelSerializer):
+class ProductStorefrontListSerializer(TranslatedSerializerMixin, ModelSerializer):
     """
-    Product serializer used for storefront.
+    Product serializer used for storefront when listing products
     Only one translation is returned (see TranslatedSerializerMixin)
     """
 

--- a/src/backend/core/product/serializers.py
+++ b/src/backend/core/product/serializers.py
@@ -513,6 +513,7 @@ class ProductStorefrontSerializer(TranslatedSerializerMixin, ModelSerializer):
     Product serializer used for storefront.
     Only one translation is returned (see TranslatedSerializerMixin)
     """
+
     class Meta:
         model = Product
         fields = (

--- a/src/backend/core/product/serializers.py
+++ b/src/backend/core/product/serializers.py
@@ -19,7 +19,6 @@ from django.db.models import (
     Max,
 )
 
-
 from category.serializers import (
     CategorySerializer,
 )
@@ -38,7 +37,6 @@ from product.models import (
     ProductMediaTypes,
     ProductType,
 )
-
 
 """
 Common serializers
@@ -482,9 +480,9 @@ class ProductDashboardDetailSerializer(TranslatableModelSerializer, ModelSeriali
         return instance
 
 
-class ProductSerializer(TranslatedSerializerMixin, ModelSerializer):
+class ProductDashboardSerializer(TranslatedSerializerMixin, ModelSerializer):
     """
-    Basic Product model serializer (see product/models.py)
+    Basic Product model serializer (see product/models.py) used for dashboard
     retrieving all fields defined in the model with nested list of product variants
     and category.
     Only one translation is returned (see TranslatedSerializerMixin)
@@ -507,4 +505,20 @@ class ProductSerializer(TranslatedSerializerMixin, ModelSerializer):
             "description_editorjs",
             "slug",
             "product_variants",
+        )
+
+
+class ProductStorefrontSerializer(TranslatedSerializerMixin, ModelSerializer):
+    """
+    Product serializer used for storefront.
+    Only one translation is returned (see TranslatedSerializerMixin)
+    """
+    class Meta:
+        model = Product
+        fields = (
+            "id",
+            "title",
+            "meta_title",
+            "meta_description",
+            "slug",
         )

--- a/src/backend/core/product/serializers.py
+++ b/src/backend/core/product/serializers.py
@@ -382,7 +382,9 @@ class ProductDashboardDetailSerializer(TranslatableModelSerializer, ModelSeriali
         many=True, read_only=False, required=False
     )
     id = CharField(required=False, read_only=True)  # for update
-    media = ProductMediaDetailsSerializer(many=True, source="product_media", read_only=True)
+    media = ProductMediaDetailsSerializer(
+        many=True, source="product_media", read_only=True
+    )
     type_id = PrimaryKeyRelatedField(
         required=False, write_only=True, queryset=ProductType.objects.all()
     )  # for update
@@ -526,6 +528,10 @@ class ProductStorefrontListSerializer(TranslatedSerializerMixin, ModelSerializer
         read_only=True, many=False, source="get_primary_photo"
     )
 
+    product_variants = ProductVariantSerializer(
+        many=True, read_only=False, required=False
+    )
+
     class Meta:
         model = Product
         fields = (
@@ -535,4 +541,5 @@ class ProductStorefrontListSerializer(TranslatedSerializerMixin, ModelSerializer
             "meta_description",
             "slug",
             "primary_image",
+            "product_variants",
         )

--- a/src/backend/core/product/serializers.py
+++ b/src/backend/core/product/serializers.py
@@ -518,12 +518,6 @@ class ProductDashboardSerializer(TranslatedSerializerMixin, ModelSerializer):
         )
 
 
-class ProductPriceStorefrontListSerializer(ModelSerializer):
-    class Meta:
-        model = ProductPrice
-        fields = ("formatted_price",)
-
-
 class ProductStorefrontListSerializer(TranslatedSerializerMixin, ModelSerializer):
     """
     Product serializer used for storefront when listing products
@@ -538,14 +532,12 @@ class ProductStorefrontListSerializer(TranslatedSerializerMixin, ModelSerializer
 
     def get_variant_prices(self, product):
         price_list = self.context.get("price_list")
+        variants = product.product_variants.all()
 
-        variant_prices = [
-            price
-            for variant in product.product_variants.all()
-            for price in variant.price.filter(price_list=price_list)
-        ]
-        serializer = ProductPriceStorefrontListSerializer(variant_prices, many=True)
-        return serializer.data
+        variant_prices = ProductPrice.objects.filter(
+            product_variant__in=variants, price_list=price_list
+        )
+        return [p.formatted_price for p in variant_prices]
 
     class Meta:
         model = Product

--- a/src/backend/core/product/serializers.py
+++ b/src/backend/core/product/serializers.py
@@ -553,14 +553,20 @@ class ProductStorefrontListSerializer(TranslatedSerializerMixin, ModelSerializer
 
     def get_price(self, product):
         cheapest_variant = self._get_cheapest_variant(product)
-        return cheapest_variant.formatted_price if cheapest_variant is not None else None
+        return (
+            cheapest_variant.formatted_price if cheapest_variant is not None else None
+        )
 
     def get_has_multiple_prices(self, product):
         cheapest_variant = self._get_cheapest_variant(product)
         if cheapest_variant is None:
             return False
         else:
-            return self._get_variant_prices(product).filter(price__gt=cheapest_variant.price).exists()
+            return (
+                self._get_variant_prices(product)
+                .filter(price__gt=cheapest_variant.price)
+                .exists()
+            )
 
     class Meta:
         model = Product
@@ -572,5 +578,5 @@ class ProductStorefrontListSerializer(TranslatedSerializerMixin, ModelSerializer
             "slug",
             "primary_image",
             "price",
-            "has_multiple_prices"
+            "has_multiple_prices",
         )

--- a/src/backend/core/product/views.py
+++ b/src/backend/core/product/views.py
@@ -17,7 +17,7 @@ from .models import (
     ProductType,
 )
 from .serializers import (
-    ProductSerializer,
+    ProductDashboardSerializer,
     ProductDashboardListSerializer,
     ProductDashboardDetailSerializer,
     PriceListBaseSerializer,
@@ -273,7 +273,7 @@ class ProductDetailStorefront(APIView):
         except Product.DoesNotExist:
             return Response({"error": "Product does not exist"}, status=404)
 
-        serialized_product = ProductSerializer(product)
+        serialized_product = ProductDashboardSerializer(product)
         return Response(serialized_product.data, status=200)
 
 

--- a/src/backend/core/product/views.py
+++ b/src/backend/core/product/views.py
@@ -24,7 +24,7 @@ from .serializers import (
     AtrributeTypeDashboardSerializer,
     BaseAttributeDashboardSerializer,
     ProductVariantSerializer,
-    ProductMediaSerializer,
+    ProductMediaDetailsSerializer,
     ProductTypeSerializer,
 )
 
@@ -281,7 +281,7 @@ class ProductMediaUpload(GenericAPIView):
     allowed_methods = ["POST"]
     permission_classes = (permissions.AllowAny,)
     parser_classes = (MultiPartParser, FormParser)
-    serializer_class = ProductMediaSerializer
+    serializer_class = ProductMediaDetailsSerializer
 
     def post(self, request, *args, **kwargs):
         product_media_serializer = self.serializer_class(
@@ -297,7 +297,7 @@ class ProductMediaUpload(GenericAPIView):
 class ProductMediaUploadDetailView(RetrieveUpdateDestroyAPIView):
     allowed_methods = ["GET", "PUT", "DELETE"]
     permission_classes = (permissions.AllowAny,)
-    serializer_class = ProductMediaSerializer
+    serializer_class = ProductMediaDetailsSerializer
     lookup_field = "id"
     lookup_url_kwarg = "id"
 

--- a/src/dashboard/api/category/category.ts
+++ b/src/dashboard/api/category/category.ts
@@ -9,7 +9,7 @@ import {
  * Get list of all categories
  */
 export const getAllCategories = async () => {
-  return await axiosPrivate.get<ICategoryLocalized[]>(`/category/`);
+  return await axiosPrivate.get<ICategoryLocalized[]>("dashboard/category/");
 };
 
 /**
@@ -17,7 +17,7 @@ export const getAllCategories = async () => {
  * @param categoryToAdd
  */
 export const addCategory = async (categoryToAdd: ICategoryEditable) => {
-  return await axiosPrivate.post(`/category/`, categoryToAdd);
+  return await axiosPrivate.post("dashboard/category/", categoryToAdd);
 };
 
 /**
@@ -25,7 +25,7 @@ export const addCategory = async (categoryToAdd: ICategoryEditable) => {
  * @param id
  */
 export const getCategory = async (id: string) => {
-  return await axiosPrivate.get<ICategoryDetail>(`/category/${id}`);
+  return await axiosPrivate.get<ICategoryDetail>(`dashboard/category/${id}`);
 };
 
 /**
@@ -37,7 +37,7 @@ export const updateCategory = async (
   id: string,
   updatedCategory: ICategoryEditable
 ) => {
-  return await axiosPrivate.put(`/category/${id}`, updatedCategory);
+  return await axiosPrivate.put(`dashboard/category/${id}`, updatedCategory);
 };
 
 /**
@@ -45,5 +45,5 @@ export const updateCategory = async (
  * @param id
  */
 export const deleteCategory = async (id: string) => {
-  return await axiosPrivate.delete(`/category/${id}`);
+  return await axiosPrivate.delete(`dashboard/category/${id}`);
 };

--- a/src/dashboard/api/category/category.ts
+++ b/src/dashboard/api/category/category.ts
@@ -9,7 +9,7 @@ import {
  * Get list of all categories
  */
 export const getAllCategories = async () => {
-  return await axiosPrivate.get<ICategoryLocalized[]>("dashboard/category/");
+  return await axiosPrivate.get<ICategoryLocalized[]>("category/dashboard/");
 };
 
 /**
@@ -17,7 +17,7 @@ export const getAllCategories = async () => {
  * @param categoryToAdd
  */
 export const addCategory = async (categoryToAdd: ICategoryEditable) => {
-  return await axiosPrivate.post("dashboard/category/", categoryToAdd);
+  return await axiosPrivate.post("category/dashboard/", categoryToAdd);
 };
 
 /**
@@ -25,7 +25,7 @@ export const addCategory = async (categoryToAdd: ICategoryEditable) => {
  * @param id
  */
 export const getCategory = async (id: string) => {
-  return await axiosPrivate.get<ICategoryDetail>(`dashboard/category/${id}`);
+  return await axiosPrivate.get<ICategoryDetail>(`category/dashboard/${id}`);
 };
 
 /**
@@ -37,7 +37,7 @@ export const updateCategory = async (
   id: string,
   updatedCategory: ICategoryEditable
 ) => {
-  return await axiosPrivate.put(`dashboard/category/${id}`, updatedCategory);
+  return await axiosPrivate.put(`category/dashboard/${id}`, updatedCategory);
 };
 
 /**
@@ -45,5 +45,5 @@ export const updateCategory = async (
  * @param id
  */
 export const deleteCategory = async (id: string) => {
-  return await axiosPrivate.delete(`dashboard/category/${id}`);
+  return await axiosPrivate.delete(`category/dashboard/${id}`);
 };

--- a/src/dashboard/api/category/category.ts
+++ b/src/dashboard/api/category/category.ts
@@ -25,7 +25,7 @@ export const addCategory = async (categoryToAdd: ICategoryEditable) => {
  * @param id
  */
 export const getCategory = async (id: string) => {
-  return await axiosPrivate.get<ICategoryDetail>(`/category/dashboard/${id}`);
+  return await axiosPrivate.get<ICategoryDetail>(`/category/dashboard/${id}/`);
 };
 
 /**
@@ -37,7 +37,7 @@ export const updateCategory = async (
   id: string,
   updatedCategory: ICategoryEditable
 ) => {
-  return await axiosPrivate.put(`/category/dashboard/${id}`, updatedCategory);
+  return await axiosPrivate.put(`/category/dashboard/${id}/`, updatedCategory);
 };
 
 /**
@@ -45,5 +45,5 @@ export const updateCategory = async (
  * @param id
  */
 export const deleteCategory = async (id: string) => {
-  return await axiosPrivate.delete(`/category/dashboard/${id}`);
+  return await axiosPrivate.delete(`/category/dashboard/${id}/`);
 };

--- a/src/dashboard/api/category/category.ts
+++ b/src/dashboard/api/category/category.ts
@@ -9,7 +9,7 @@ import {
  * Get list of all categories
  */
 export const getAllCategories = async () => {
-  return await axiosPrivate.get<ICategoryLocalized[]>("category/dashboard/");
+  return await axiosPrivate.get<ICategoryLocalized[]>("/category/dashboard/");
 };
 
 /**
@@ -17,7 +17,7 @@ export const getAllCategories = async () => {
  * @param categoryToAdd
  */
 export const addCategory = async (categoryToAdd: ICategoryEditable) => {
-  return await axiosPrivate.post("category/dashboard/", categoryToAdd);
+  return await axiosPrivate.post("/category/dashboard/", categoryToAdd);
 };
 
 /**
@@ -25,7 +25,7 @@ export const addCategory = async (categoryToAdd: ICategoryEditable) => {
  * @param id
  */
 export const getCategory = async (id: string) => {
-  return await axiosPrivate.get<ICategoryDetail>(`category/dashboard/${id}`);
+  return await axiosPrivate.get<ICategoryDetail>(`/category/dashboard/${id}`);
 };
 
 /**
@@ -37,7 +37,7 @@ export const updateCategory = async (
   id: string,
   updatedCategory: ICategoryEditable
 ) => {
-  return await axiosPrivate.put(`category/dashboard/${id}`, updatedCategory);
+  return await axiosPrivate.put(`/category/dashboard/${id}`, updatedCategory);
 };
 
 /**
@@ -45,5 +45,5 @@ export const updateCategory = async (
  * @param id
  */
 export const deleteCategory = async (id: string) => {
-  return await axiosPrivate.delete(`category/dashboard/${id}`);
+  return await axiosPrivate.delete(`/category/dashboard/${id}`);
 };

--- a/src/storefront/pages/api/category/index.ts
+++ b/src/storefront/pages/api/category/index.ts
@@ -9,7 +9,7 @@ export const categoryAPI = async (
   locale: string
 ) => {
   return await api
-    .get(`/category/`, {
+    .get(`/category/storefront/`, {
       headers: { "Accept-Language": locale },
     })
     .then((response: any) => response.data)


### PR DESCRIPTION
# Work done

- All dashboard endpoint URLs now contain `dasboard`.
i.e. `category/<int:pk>/` was changed to `category/dashboard/<int:pk>/`

Added several new endpoint to API:
- `GET category/storefront/`: returns tree of all published categories
  Example output: 
  ```json
  [
      {
          "id": 7,
          "title": "abcdef",
          "meta_title": "asdf",
          "slug": "abcdef",
          "children": [
              {
                  "id": 2,
                  "title": "sec",
                  "meta_title": "",
                  "slug": "d",
                  "children": []
              }
          ]
      },
      {
          "id": 9,
          "title": "asdf",
          "meta_title": "",
          "slug": "afds",
          "children": []
      }
  ]
  ```
  These data are being used in storefront menu.

- `GET category/storefront/<int:pk>/`: returns detail of the selected category (including its children)
  Example output:
  ```json
    {
      "id": 7,
      "title": "abcdef",
      "meta_title": "asdf",
      "slug": "abcdef",
      "children": [
          {
              "id": 2,
              "title": "sec",
              "meta_title": "",
              "slug": "d",
              "children": [],
              "description": "d",
              "meta_description": ""
          }
      ],
      "description": "first",
      "meta_description": "asdf"
  }
  ```
  These data are intended to be used on category detail storefront page.
  
- `GET category/storefront/<int:pk>/products/`: returns data about all products in the given category (or its subcategories)
  Example output:
  ```json
    [
      {
          "id": 1,
          "title": "dfdf NEW text xx ddddd",
          "meta_title": "asd",
          "meta_description": "asdf",
          "slug": "dfdf-new-text-xx-ddddd"
      },
      {
          "id": 2,
          "title": "a",
          "meta_title": "a",
          "meta_description": "a",
          "slug": "a"
      }
  ]
  ```
  These data are also intended to be used on category detail page - as a list of products contained in the given category
  