### PR TITLE
[T-167] Environment variable enabling/disabling recommender system introduced

### DIFF
--- a/src/backend/.env.default
+++ b/src/backend/.env.default
@@ -1,1 +1,2 @@
 RS_URL="localhost:8086"
+# RS_ENABLED="FALSE"

--- a/src/backend/core/api/recommender_system.py
+++ b/src/backend/core/api/recommender_system.py
@@ -6,9 +6,11 @@ from django.conf import settings
 
 class RecommenderSystemApi:
     server_url: str = settings.RS_URL
+    valid: bool = settings.RS_ENABLED
 
     @classmethod
     def store_object(cls, data: Dict[str, Any]) -> None:
-        _ = requests.request(
-            method="POST", url=cls.server_url + "/store_object", json=data
-        )
+        if cls.valid:
+            _ = requests.request(
+                method="POST", url=cls.server_url + "/store_object", json=data
+            )

--- a/src/backend/core/api/recommender_system.py
+++ b/src/backend/core/api/recommender_system.py
@@ -6,11 +6,11 @@ from django.conf import settings
 
 class RecommenderSystemApi:
     server_url: str = settings.RS_URL
-    valid: bool = settings.RS_ENABLED
+    enabled: bool = settings.RS_ENABLED
 
     @classmethod
     def store_object(cls, data: Dict[str, Any]) -> None:
-        if cls.valid:
+        if cls.enabled:
             _ = requests.request(
                 method="POST", url=cls.server_url + "/store_object", json=data
             )

--- a/src/backend/core/core/settings.py
+++ b/src/backend/core/core/settings.py
@@ -218,3 +218,4 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 AUTH_USER_MODEL = "user.User"
 
 RS_URL = os.environ.get("RS_URL", "")
+RS_ENABLED = os.environ.get("RS_ENABLED", "TRUE").upper() == "TRUE"


### PR DESCRIPTION
... say hello 👋 

Ecoseller can now run without recommender system. All you need to do is set `RS_ENABLED` to `"FALSE"` (technically to anything except `"TRUE"`) and core will not try to connect to recommender system via API. If this environment variable is missing, the recommender system is enabled.