### PR TITLE
[T-187] Category saved to RS database

### DIFF
--- a/src/backend/core/category/models.py
+++ b/src/backend/core/category/models.py
@@ -5,6 +5,8 @@ from django_editorjs_fields import EditorJsJSONField
 from mptt.models import MPTTModel
 from mptt.fields import TreeForeignKey
 
+from api.recommender_system import RecommenderSystemApi
+
 
 class Category(MPTTModel, TranslatableModel):
     parent = TreeForeignKey(
@@ -44,3 +46,19 @@ class Category(MPTTModel, TranslatableModel):
     @property
     def all_children(self):
         return self.get_children()
+
+    def save(
+        self, force_insert=False, force_update=False, using=None, update_fields=None
+    ):
+        super().save(
+            force_insert=force_insert,
+            force_update=force_update,
+            using=using,
+            update_fields=update_fields,
+        )
+        data = {
+            "_model_class": self.__class__.__name__,
+            "id": self.id,
+            "parent_id": self.parent.id,
+        }
+        RecommenderSystemApi.store_object(data=data)

--- a/src/recommender_system/app/recommender_system/managers/data_manager.py
+++ b/src/recommender_system/app/recommender_system/managers/data_manager.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Type
 from recommender_system.models.api.attribute import Attribute
 from recommender_system.models.api.attribute_type import AttributeType
 from recommender_system.models.api.base import ApiBaseModel
+from recommender_system.models.api.category import Category
 from recommender_system.models.api.product import Product
 from recommender_system.models.api.product_add_to_cart import ProductAddToCart
 from recommender_system.models.api.product_detail_enter import ProductDetailEnter
@@ -19,6 +20,7 @@ class DataManager:
     _model_class_map: Dict[str, Type[ApiBaseModel]] = {
         "Attribute": Attribute,
         "AttributeType": AttributeType,
+        "Category": Category,
         "Product": Product,
         "ProductAddToCart": ProductAddToCart,
         "ProductDetailEnter": ProductDetailEnter,

--- a/src/recommender_system/app/recommender_system/models/api/category.py
+++ b/src/recommender_system/app/recommender_system/models/api/category.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+from recommender_system.models.api.base import ApiBaseModel
+from recommender_system.models.stored.product.category_ancestor import (
+    CategoryAncestorModel,
+)
+
+
+class Category(ApiBaseModel):
+    """
+    This model represents category as an object that is sent from
+    core to RS component via API.
+    """
+
+    id: int
+    parent_id: Optional[int]
+
+    def save(self) -> None:
+        """
+        Updates CategoryAncestorModel objects in the database.
+
+        Returns
+        -------
+        None
+
+        """
+        for ancestor in CategoryAncestorModel.gets(category_id=self.id):
+            ancestor.delete()
+        if self.parent_id is not None:
+            parent_ancestors = CategoryAncestorModel.gets(category_id=self.parent_id)
+            for ancestor in parent_ancestors:
+                CategoryAncestorModel(
+                    category_id=self.id,
+                    category_ancestor_id=ancestor.category_ancestor_id,
+                ).create()
+            CategoryAncestorModel(
+                category_id=self.id,
+                category_ancestor_id=self.parent_id,
+            ).create()


### PR DESCRIPTION
Category is now saved from core to RS on update.

Categories are technically not stored in RS, only the category tree is stored there - entry for each category and its ancestor (every node on the path to the root) is stored in the database. This allows prediction to include all subcategories to be accessed faster than by inspecting the whole subtree below a specified category.