### PR TITLE
[T-41]: Shipping/Billing info in cart (Step1)

### DIFF
--- a/src/backend/core/cart/serializers.py
+++ b/src/backend/core/cart/serializers.py
@@ -35,6 +35,11 @@ from product.serializers import (
     ProductMediaBaseSerializer,
 )
 
+from country.serializers import (
+    ShippingInfoSerializer,
+    BillingInfoSerializer,
+)
+
 
 class FileImageField(Base64FileField):
     ALLOWED_TYPES = ["png", "jpg", "jpeg", "gif", "svg"]
@@ -102,8 +107,8 @@ class CartSerializer(ModelSerializer):
     #     write_only=True,
     #     required=False,
     # )
-    # shipping_info = ShippingInfoSerializer(read_only=True)
-    # billing_info = BillingInfoSerializer(read_only=True)
+    shipping_info = ShippingInfoSerializer(read_only=True)
+    billing_info = BillingInfoSerializer(read_only=True)
     # pricelist = PriceListSerializer(read_only=True, many=False)
 
     currency_symbol = SerializerMethodField()
@@ -111,7 +116,14 @@ class CartSerializer(ModelSerializer):
 
     class Meta:
         model = Cart
-        fields = ("cart_items", "update_at", "currency_symbol", "symbol_position")
+        fields = (
+            "cart_items",
+            "update_at",
+            "currency_symbol",
+            "symbol_position",
+            "shipping_info",
+            "billing_info",
+        )
 
     def get_currency_symbol(self, obj):
         return obj.pricelist.currency.symbol

--- a/src/backend/core/cart/serializers.py
+++ b/src/backend/core/cart/serializers.py
@@ -93,24 +93,6 @@ class CartSerializer(ModelSerializer):
     """
 
     cart_items = CartItemDetailSerializer(many=True, read_only=True)
-
-    # country = CountrySerializer(read_only=True)
-    # shipping_info_id = PrimaryKeyRelatedField(
-    #     queryset=ShippingInfo.objects.all(),
-    #     source="shipping_info",
-    #     write_only=True,
-    #     required=False,
-    # )
-    # billing_info_id = PrimaryKeyRelatedField(
-    #     queryset=BillingInfo.objects.all(),
-    #     source="billing_info",
-    #     write_only=True,
-    #     required=False,
-    # )
-    shipping_info = ShippingInfoSerializer(read_only=True)
-    billing_info = BillingInfoSerializer(read_only=True)
-    # pricelist = PriceListSerializer(read_only=True, many=False)
-
     currency_symbol = SerializerMethodField()
     symbol_position = SerializerMethodField()
 
@@ -121,8 +103,6 @@ class CartSerializer(ModelSerializer):
             "update_at",
             "currency_symbol",
             "symbol_position",
-            "shipping_info",
-            "billing_info",
         )
 
     def get_currency_symbol(self, obj):

--- a/src/backend/core/cart/serializers.py
+++ b/src/backend/core/cart/serializers.py
@@ -35,11 +35,6 @@ from product.serializers import (
     ProductMediaBaseSerializer,
 )
 
-from country.serializers import (
-    ShippingInfoSerializer,
-    BillingInfoSerializer,
-)
-
 
 class FileImageField(Base64FileField):
     ALLOWED_TYPES = ["png", "jpg", "jpeg", "gif", "svg"]

--- a/src/backend/core/cart/views.py
+++ b/src/backend/core/cart/views.py
@@ -15,6 +15,7 @@ from rest_framework.status import (
     HTTP_404_NOT_FOUND,
     HTTP_400_BAD_REQUEST,
     HTTP_204_NO_CONTENT,
+    HTTP_200_OK,
     HTTP_201_CREATED,
 )
 from rest_framework.views import APIView
@@ -219,6 +220,15 @@ class CartUpdateInfoBaseStorefrontView(APIView, ABC):
         """
         pass
 
+    def get(self, request, token):
+        try:
+            cart = Cart.objects.get(token=token)
+            info = self._get_info(cart)
+            serializer = self.info_serializer(info)
+            return Response(status=HTTP_200_OK, data=serializer.data)
+        except Cart.DoesNotExist:
+            return Response(status=HTTP_404_NOT_FOUND)
+
     def put(self, request, token):
         try:
             cart = Cart.objects.get(token=token)
@@ -230,9 +240,10 @@ class CartUpdateInfoBaseStorefrontView(APIView, ABC):
                 # if we don't have info, create it
                 serializer = self.info_serializer(data=request.data)
             if serializer.is_valid():
-                serializer.save()
+                info = serializer.save()
                 self._set_info(cart, info)
                 return Response(status=HTTP_204_NO_CONTENT)
+            print(serializer.errors)
             return Response(serializer.errors, status=HTTP_400_BAD_REQUEST)
         except Cart.DoesNotExist:
             return Response(status=HTTP_404_NOT_FOUND)

--- a/src/storefront/api/cart/info.ts
+++ b/src/storefront/api/cart/info.ts
@@ -6,9 +6,6 @@ export const putShippingInfo = async (
 ) => {
   const response = await fetch(`/api/cart/${token}/shipping-info/`, {
     method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
     body: JSON.stringify(shippingInfo),
   });
 
@@ -21,9 +18,6 @@ export const putBillingInfo = async (
 ) => {
   const response = await fetch(`/api/cart/${token}/billing-info/`, {
     method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
     body: JSON.stringify(billingInfo),
   });
 

--- a/src/storefront/api/cart/info.ts
+++ b/src/storefront/api/cart/info.ts
@@ -1,0 +1,31 @@
+import { IBillingInfo, IShippingInfo } from "@/types/cart";
+
+export const putShippingInfo = async (
+  token: string,
+  shippingInfo: IShippingInfo
+) => {
+  const response = await fetch(`/api/cart/${token}/shipping-info/`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(shippingInfo),
+  });
+
+  return await response.status;
+};
+
+export const putBillingInfo = async (
+  token: string,
+  billingInfo: IBillingInfo
+) => {
+  const response = await fetch(`/api/cart/${token}/billing-info/`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(billingInfo),
+  });
+
+  return await response.status;
+};

--- a/src/storefront/components/Cart/ButtonRow.tsx
+++ b/src/storefront/components/Cart/ButtonRow.tsx
@@ -1,0 +1,54 @@
+import Button from "@mui/material/Button";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+
+interface IButton {
+  onClick: () => void;
+  title: string;
+  disabled: boolean;
+}
+
+interface ICartButtonRowProps {
+  prev: IButton;
+  next: IButton;
+}
+
+const CartButtonRow = (props: ICartButtonRowProps) => {
+  const { prev, next } = props;
+  return (
+    <Grid
+      container
+      spacing={{ xs: 0, md: 4, lg: 4 }}
+      columns={{ xs: 10, sm: 10, md: 12 }}
+      pt={4}
+    >
+      <Grid container item xs={2} sm={2} md={2} direction="column" pt={4}>
+        <Typography
+          variant="body1"
+          sx={{
+            cursor: "pointer",
+            textDecoration: "underline",
+            "&:hover": {
+              color: "primary.main",
+            },
+          }}
+          onClick={prev.onClick}
+        >
+          {prev.title}
+        </Typography>
+      </Grid>
+      <Grid container item xs={6} sm={7} md={7} direction="column" pt={4} />
+      <Grid container item xs={1} sm={1} md={1} direction="column" pt={4}>
+        <Button
+          variant={"contained"}
+          disabled={next.disabled}
+          onClick={next.onClick}
+        >
+          {next.title}
+        </Button>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default CartButtonRow;

--- a/src/storefront/components/Cart/Stepper.tsx
+++ b/src/storefront/components/Cart/Stepper.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Stepper from "@mui/material/Stepper";
+import Step from "@mui/material/Step";
+import StepLabel from "@mui/material/StepLabel";
+
+const steps = [
+  "Cart",
+  "Shipping & billing info",
+  "Shipping & payment method",
+  "Order summary",
+];
+
+interface ICartStepper {
+  activeStep: number;
+}
+
+const CartStepper = ({ activeStep }: ICartStepper) => {
+  return (
+    <Box sx={{ width: "100%" }} pt={4} pb={2}>
+      <Stepper activeStep={activeStep} alternativeLabel>
+        {steps.map((label) => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+    </Box>
+  );
+};
+
+export default CartStepper;

--- a/src/storefront/components/Forms/BasicField.tsx
+++ b/src/storefront/components/Forms/BasicField.tsx
@@ -1,23 +1,30 @@
 import { IValidatedInputField } from "@/types/common";
+import Box from "@mui/material/Box";
 import TextField from "@mui/material/TextField";
 import { ChangeEvent } from "react";
 
 const BasicField = ({ field }: { field: IValidatedInputField }) => {
   return (
-    <TextField
-      id="first-name"
-      label={field.label}
-      variant="outlined"
-      value={field.value}
-      onChange={(e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-        field.setter(e.target.value);
-        if (field.validator && field.setIsValid) {
-          field.setIsValid(field.validator(e.target.value));
-        }
-      }}
-      error={field.isValid === false}
-      helperText={!field.isValid ? field?.errorMessage : ""}
-    />
+    <Box pt={2} pr={2}>
+      <TextField
+        id="first-name"
+        label={field.label}
+        variant="outlined"
+        value={field.value}
+        onChange={(e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+          field.setter(e.target.value);
+          if (field.validator && field.setIsValid) {
+            field.setIsValid(field.validator(e.target.value));
+          }
+        }}
+        error={field.isValid === false}
+        helperText={!field.isValid ? field?.errorMessage : ""}
+        fullWidth
+        sx={{
+          display: "block",
+        }}
+      />
+    </Box>
   );
 };
 

--- a/src/storefront/components/Forms/BasicField.tsx
+++ b/src/storefront/components/Forms/BasicField.tsx
@@ -1,0 +1,24 @@
+import { IValidatedInputField } from "@/types/common";
+import TextField from "@mui/material/TextField";
+import { ChangeEvent } from "react";
+
+const BasicField = ({ field }: { field: IValidatedInputField }) => {
+  return (
+    <TextField
+      id="first-name"
+      label={field.label}
+      variant="outlined"
+      value={field.value}
+      onChange={(e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+        field.setter(e.target.value);
+        if (field.validator && field.setIsValid) {
+          field.setIsValid(field.validator(e.target.value));
+        }
+      }}
+      error={field.isValid === false}
+      helperText={!field.isValid ? field?.errorMessage : ""}
+    />
+  );
+};
+
+export default BasicField;

--- a/src/storefront/components/Forms/BasicField.tsx
+++ b/src/storefront/components/Forms/BasicField.tsx
@@ -1,7 +1,72 @@
 import { IValidatedInputField } from "@/types/common";
 import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
+import MenuItem from "@mui/material/MenuItem";
 import { ChangeEvent } from "react";
+
+interface IBasicSelectOption {
+  code: string;
+  name: string;
+}
+export interface IBasicSelect {
+  field: IValidatedInputField;
+  options: IBasicSelectOption[];
+  disabled?: boolean;
+}
+
+export const BasicSelect = ({ field, options, disabled }: IBasicSelect) => {
+  console.log("options", options);
+  return (
+    <Box pt={2} pr={2}>
+      <TextField
+        id="outlined-select-currency"
+        select
+        label={field.label}
+        value={field.value}
+        defaultValue={field.value}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+          if (disabled) {
+            return;
+          }
+          field.setter(e.target.value);
+        }}
+        variant="outlined"
+        fullWidth
+        disabled={disabled}
+      >
+        {options.map((option) => (
+          <MenuItem key={option.code} value={option.code}>
+            {option.name}
+          </MenuItem>
+        ))}
+      </TextField>
+    </Box>
+  );
+};
+
+export const TwoFieldsOneRowWrapper = ({
+  children,
+}: {
+  children: JSX.Element[];
+}) => {
+  if (children.length !== 2)
+    throw new Error("TwoFieldsOneRowWrapper must have exactly two children");
+  return (
+    <Grid
+      container
+      spacing={{ xs: 1, md: 1 }}
+      columns={{ xs: 4, sm: 12, md: 12 }}
+    >
+      <Grid item xs={4} sm={6} md={6}>
+        {children[0]}
+      </Grid>
+      <Grid item xs={4} sm={6} md={6}>
+        {children[1]}
+      </Grid>
+    </Grid>
+  );
+};
 
 const BasicField = ({ field }: { field: IValidatedInputField }) => {
   return (

--- a/src/storefront/components/Forms/BillingInfoForm.tsx
+++ b/src/storefront/components/Forms/BillingInfoForm.tsx
@@ -1,4 +1,4 @@
-import { IBillingInfo } from "@/types/cart";
+import { IBillingInfo, ICountryOption } from "@/types/cart";
 import { IValidatedInputField } from "@/types/common";
 import TextField from "@mui/material/TextField";
 import {
@@ -8,7 +8,7 @@ import {
   useCallback,
   useEffect,
 } from "react";
-import BasicField from "./BasicField";
+import BasicField, { BasicSelect, TwoFieldsOneRowWrapper } from "./BasicField";
 
 export interface IBillingInfoFormProps {
   first_name: IValidatedInputField;
@@ -203,10 +203,18 @@ export const billingInfoInitialData = (
 interface IBillingInfoFormComponentProps extends IBillingInfoFormProps {
   setIsFormValid: (value: boolean) => void;
   radioType?: "NEW" | "SAMEASSHIPPING";
+  countryOptions?: ICountryOption[];
+  allowCountryChange?: boolean;
 }
 
 const BillingInfoForm = (props: IBillingInfoFormComponentProps) => {
-  const { setIsFormValid, radioType, ...billingInfo } = props;
+  const {
+    setIsFormValid,
+    radioType,
+    countryOptions,
+    allowCountryChange = false,
+    ...billingInfo
+  } = props;
 
   /**
    * Purpose of this component is to display the billing information form
@@ -238,12 +246,15 @@ const BillingInfoForm = (props: IBillingInfoFormComponentProps) => {
     // iterate through the billing info and check if all the fields are valid if they're required
     const billingInfoValues: IValidatedInputField[] =
       Object.values(billingInfo);
+    const billingInfoKeys: string[] = Object.keys(billingInfo);
+
     console.log("billingInfoValues", billingInfoValues);
     for (let i = 0; i < billingInfoValues.length; i++) {
       const value = billingInfoValues[i];
       if (
         value.isRequired &&
-        (value.isValid == false || value.isValid == undefined)
+        (value.isValid == false || value.isValid == undefined) &&
+        !(billingInfoKeys[i] == "country" && allowCountryChange)
       ) {
         setIsFormValid(false);
         return;
@@ -271,18 +282,29 @@ const BillingInfoForm = (props: IBillingInfoFormComponentProps) => {
     postal_code,
     country,
   } = billingInfo;
-
   return (
     <form>
-      <BasicField field={first_name} />
-      <BasicField field={surname} />
+      <TwoFieldsOneRowWrapper>
+        <BasicField field={first_name} />
+        <BasicField field={surname} />
+      </TwoFieldsOneRowWrapper>
       <BasicField field={company_name} />
-      <BasicField field={company_id} />
-      <BasicField field={vat_number} />
+      <TwoFieldsOneRowWrapper>
+        <BasicField field={company_id} />
+        <BasicField field={vat_number} />
+      </TwoFieldsOneRowWrapper>
       <BasicField field={street} />
-      <BasicField field={city} />
-      <BasicField field={postal_code} />
-      <BasicField field={country} />
+      <TwoFieldsOneRowWrapper>
+        <BasicField field={city} />
+        <BasicField field={postal_code} />
+      </TwoFieldsOneRowWrapper>
+      {countryOptions && countryOptions?.length > 0 ? (
+        <BasicSelect
+          field={country}
+          options={countryOptions}
+          disabled={!allowCountryChange}
+        />
+      ) : null}
     </form>
   );
 };

--- a/src/storefront/components/Forms/BillingInfoForm.tsx
+++ b/src/storefront/components/Forms/BillingInfoForm.tsx
@@ -1,4 +1,5 @@
 import { IBillingInfo } from "@/types/cart";
+import { IValidatedInputField } from "@/types/common";
 import TextField from "@mui/material/TextField";
 import {
   ChangeEvent,
@@ -7,17 +8,7 @@ import {
   useCallback,
   useEffect,
 } from "react";
-
-export interface IValidatedInputField {
-  value: string;
-  isValid?: boolean;
-  setter: (value: string) => void;
-  setIsValid?: (value: boolean) => void;
-  validator?: (value: string) => boolean;
-  isRequired?: boolean;
-  errorMessage?: string;
-  label?: string;
-}
+import BasicField from "./BasicField";
 
 export interface IBillingInfoFormProps {
   first_name: IValidatedInputField;
@@ -251,143 +242,15 @@ const BillingInfoForm = (props: IBillingInfoFormComponentProps) => {
     <div className="billing-info-form">
       <h2>Billing information</h2>
       <form>
-        <TextField
-          id="first-name"
-          label={first_name.label}
-          variant="outlined"
-          value={first_name.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            first_name.setter(e.target.value);
-            if (first_name.validator && first_name.setIsValid) {
-              first_name.setIsValid(first_name.validator(e.target.value));
-            }
-          }}
-          error={first_name.isValid === false}
-          helperText={!first_name.isValid ? first_name.errorMessage : ""}
-        />
-        <TextField
-          id="surname"
-          label="Surname"
-          variant="outlined"
-          value={surname.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            surname.setter(e.target.value);
-            if (surname.validator && surname.setIsValid) {
-              surname.setIsValid(surname.validator(e.target.value));
-            }
-          }}
-          error={surname.isValid === false}
-          helperText={!surname.isValid ? surname.errorMessage : ""}
-        />
-        <TextField
-          id="company-name"
-          label={company_name.label}
-          variant="outlined"
-          value={company_name.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            company_name.setter(e.target.value);
-            if (company_name.validator && company_name.setIsValid) {
-              company_name.setIsValid(company_name.validator(e.target.value));
-            }
-          }}
-          error={company_name.isValid === false}
-          helperText={!company_name.isValid ? company_name.errorMessage : ""}
-        />
-        <TextField
-          id="company-id"
-          label={company_id.label}
-          variant="outlined"
-          value={company_id.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            company_id.setter(e.target.value);
-            if (company_id.validator && company_id.setIsValid) {
-              company_id.setIsValid(company_id.validator(e.target.value));
-            }
-          }}
-          error={company_id.isValid === false}
-          helperText={!company_id.isValid ? company_id.errorMessage : ""}
-        />
-        <TextField
-          id="vat-number"
-          label={vat_number.label}
-          variant="outlined"
-          value={vat_number.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            vat_number.setter(e.target.value);
-            if (vat_number.validator && vat_number.setIsValid) {
-              vat_number.setIsValid(vat_number.validator(e.target.value));
-            }
-          }}
-        />
-        <TextField
-          id="street"
-          label={street.label}
-          variant="outlined"
-          value={street.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            street.setter(e.target.value);
-            if (street.validator && street.setIsValid) {
-              street.setIsValid(street.validator(e.target.value));
-            }
-          }}
-          error={street.isValid === false}
-          helperText={!street.isValid ? street.errorMessage : ""}
-        />
-        <TextField
-          id="city"
-          label={city.label}
-          variant="outlined"
-          value={city.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            city.setter(e.target.value);
-            if (city.validator && city.setIsValid) {
-              city.setIsValid(city.validator(e.target.value));
-            }
-          }}
-          error={city.isValid === false}
-          helperText={!city.isValid ? city.errorMessage : ""}
-        />
-        <TextField
-          id="postal-code"
-          label={postal_code.label}
-          variant="outlined"
-          value={postal_code.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            postal_code.setter(e.target.value);
-            if (postal_code.validator && postal_code.setIsValid) {
-              postal_code.setIsValid(postal_code.validator(e.target.value));
-            }
-          }}
-          error={postal_code.isValid === false}
-          helperText={!postal_code.isValid ? postal_code.errorMessage : ""}
-        />
-        <TextField
-          id="country"
-          label={country.label}
-          variant="outlined"
-          value={country.value}
-          onChange={(e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) =>
-            country.setter(e.target.value)
-          }
-          error={country.isValid === false}
-          helperText={!country.isValid ? country.errorMessage : ""}
-        />
+        <BasicField field={first_name} />
+        <BasicField field={surname} />
+        <BasicField field={company_name} />
+        <BasicField field={company_id} />
+        <BasicField field={vat_number} />
+        <BasicField field={street} />
+        <BasicField field={city} />
+        <BasicField field={postal_code} />
+        <BasicField field={country} />
       </form>
     </div>
   );

--- a/src/storefront/components/Forms/BillingInfoForm.tsx
+++ b/src/storefront/components/Forms/BillingInfoForm.tsx
@@ -1,4 +1,4 @@
-import { IShippingInfo } from "@/types/cart";
+import { IBillingInfo } from "@/types/cart";
 import TextField from "@mui/material/TextField";
 import {
   ChangeEvent,
@@ -19,31 +19,31 @@ export interface IValidatedInputField {
   label?: string;
 }
 
-export interface IShippingInfoFormProps {
+export interface IBillingInfoFormProps {
   first_name: IValidatedInputField;
   surname: IValidatedInputField;
-  email: IValidatedInputField;
-  phone: IValidatedInputField;
-  additional_info: IValidatedInputField;
+  company_name: IValidatedInputField;
+  company_id: IValidatedInputField;
+  vat_number: IValidatedInputField;
   street: IValidatedInputField;
   city: IValidatedInputField;
   postal_code: IValidatedInputField;
   country: IValidatedInputField;
 }
 
-export const shippingInfoInitialData = (
-  shippingInfo: IShippingInfo,
-  setter: Dispatch<SetStateAction<IShippingInfoFormProps>>
-): IShippingInfoFormProps => {
+export const billingInfoInitialData = (
+  billingInfo: IBillingInfo,
+  setter: Dispatch<SetStateAction<IBillingInfoFormProps>>
+): IBillingInfoFormProps => {
   /**
-   * Purpose of this function is to take the shipping info from the API and
-   * convert it into the format that the ShippingInfoForm component expects.
+   * Purpose of this function is to take the billing info from the API and
+   * convert it into the format that the BillingInfoForm component expects.
    * */
 
   return {
     first_name: {
-      value: shippingInfo.first_name,
-      isValid: shippingInfo.first_name != "" ? true : undefined,
+      value: billingInfo.first_name,
+      isValid: billingInfo.first_name != "" ? true : undefined,
       setIsValid: (value: boolean) =>
         setter((prevState) => ({
           ...prevState,
@@ -60,8 +60,8 @@ export const shippingInfoInitialData = (
       label: "First name",
     },
     surname: {
-      value: shippingInfo.surname,
-      isValid: shippingInfo.surname != "" ? true : undefined,
+      value: billingInfo.surname,
+      isValid: billingInfo.surname != "" ? true : undefined,
       setIsValid: (value: boolean) =>
         setter((prevState) => ({
           ...prevState,
@@ -77,58 +77,42 @@ export const shippingInfoInitialData = (
       errorMessage: "Surname is required",
       label: "Surname",
     },
-    email: {
-      value: shippingInfo.email,
-      isValid: shippingInfo.email != "" ? true : undefined,
-      setIsValid: (value: boolean) =>
-        setter((prevState) => ({
-          ...prevState,
-          email: { ...prevState.email, isValid: value },
-        })),
+    company_name: {
+      value: billingInfo.company_name,
+      isValid: true,
       setter: (value: string) =>
         setter((prevState) => ({
           ...prevState,
-          email: { ...prevState.email, value },
-        })),
-      validator: (value: string) => {
-        const emailRegex = /\S+@\S+\.\S+/;
-        return emailRegex.test(value);
-      },
-      isRequired: true,
-      errorMessage: "Email is required",
-      label: "Email",
-    },
-    phone: {
-      value: shippingInfo.phone,
-      isValid: shippingInfo.phone != "" ? true : undefined,
-      setIsValid: (value: boolean) =>
-        setter((prevState) => ({
-          ...prevState,
-          phone: { ...prevState.phone, isValid: value },
-        })),
-      setter: (value: string) =>
-        setter((prevState) => ({
-          ...prevState,
-          phone: { ...prevState.phone, value },
-        })),
-      validator: (value: string) => value.length > 0,
-      isRequired: true,
-      errorMessage: "Phone is required",
-      label: "Phone",
-    },
-    additional_info: {
-      value: shippingInfo.additional_info,
-      setter: (value: string) =>
-        setter((prevState) => ({
-          ...prevState,
-          additional_info: { ...prevState.additional_info, value },
+          email: { ...prevState.company_name, value },
         })),
       isRequired: false,
-      label: "Additional info",
+      label: "Company name",
+    },
+    company_id: {
+      value: billingInfo.company_id,
+      isValid: true,
+      setter: (value: string) =>
+        setter((prevState) => ({
+          ...prevState,
+          company_id: { ...prevState.company_id, value },
+        })),
+      isRequired: false,
+      label: "Company ID",
+    },
+    vat_number: {
+      value: billingInfo.vat_number,
+      isValid: true,
+      setter: (value: string) =>
+        setter((prevState) => ({
+          ...prevState,
+          email: { ...prevState.vat_number, value },
+        })),
+      isRequired: false,
+      label: "VAT ID",
     },
     street: {
-      value: shippingInfo.street,
-      isValid: shippingInfo.street != "" ? true : undefined,
+      value: billingInfo.street,
+      isValid: billingInfo.street != "" ? true : undefined,
       setIsValid: (value: boolean) =>
         setter((prevState) => ({
           ...prevState,
@@ -145,8 +129,8 @@ export const shippingInfoInitialData = (
       label: "Street",
     },
     city: {
-      value: shippingInfo.city,
-      isValid: shippingInfo.city != "" ? true : undefined,
+      value: billingInfo.city,
+      isValid: billingInfo.city != "" ? true : undefined,
       setIsValid: (value: boolean) =>
         setter((prevState) => ({
           ...prevState,
@@ -163,8 +147,8 @@ export const shippingInfoInitialData = (
       label: "City",
     },
     postal_code: {
-      value: shippingInfo.postal_code,
-      isValid: shippingInfo.postal_code != "" ? true : undefined,
+      value: billingInfo.postal_code,
+      isValid: billingInfo.postal_code != "" ? true : undefined,
       setIsValid: (value: boolean) =>
         setter((prevState) => ({
           ...prevState,
@@ -181,8 +165,8 @@ export const shippingInfoInitialData = (
       label: "Postal code",
     },
     country: {
-      value: `${shippingInfo.country}`,
-      isValid: `${shippingInfo.country}` != "" ? true : undefined,
+      value: `${billingInfo.country}`,
+      isValid: `${billingInfo.country}` != "" ? true : undefined,
       setIsValid: (value: boolean) =>
         setter((prevState) => ({
           ...prevState,
@@ -201,18 +185,18 @@ export const shippingInfoInitialData = (
   };
 };
 
-interface IShippingInfoFormComponentProps extends IShippingInfoFormProps {
+interface IBillingInfoFormComponentProps extends IBillingInfoFormProps {
   setIsFormValid: (value: boolean) => void;
 }
 
-const ShippingInfoForm = (props: IShippingInfoFormComponentProps) => {
-  const { setIsFormValid, ...shippingInfo } = props;
+const BillingInfoForm = (props: IBillingInfoFormComponentProps) => {
+  const { setIsFormValid, ...billingInfo } = props;
 
   /**
-   * Purpose of this component is to display the shipping information form
-   * and have it be pre-populated with the shipping information if it exists.
+   * Purpose of this component is to display the billing information form
+   * and have it be pre-populated with the billing information if it exists.
    *
-   * It should be a form with header "Shipping information" and the following fields:
+   * It should be a form with header "Billing information" and the following fields:
    * - First name
    * - Surname
    * - Email
@@ -226,12 +210,12 @@ const ShippingInfoForm = (props: IShippingInfoFormComponentProps) => {
    * And all done in MUI with validation.
    * */
 
-  const validateShippingInfo = useCallback(() => {
-    // iterate through the shipping info and check if all the fields are valid if they're required
-    const shippingInfoValues: IValidatedInputField[] =
-      Object.values(shippingInfo);
-    for (let i = 0; i < shippingInfoValues.length; i++) {
-      const value = shippingInfoValues[i];
+  const validateBillingInfo = useCallback(() => {
+    // iterate through the billing info and check if all the fields are valid if they're required
+    const billingInfoValues: IValidatedInputField[] =
+      Object.values(billingInfo);
+    for (let i = 0; i < billingInfoValues.length; i++) {
+      const value = billingInfoValues[i];
       if (
         value.isRequired &&
         (value.isValid == false || value.isValid == undefined)
@@ -240,32 +224,32 @@ const ShippingInfoForm = (props: IShippingInfoFormComponentProps) => {
         return;
       }
     }
-    if (shippingInfoValues.length === 0) {
+    if (billingInfoValues.length === 0) {
       setIsFormValid(false);
       return;
     }
     setIsFormValid(true);
-  }, [shippingInfo]);
+  }, [billingInfo]);
 
   useEffect(() => {
-    validateShippingInfo();
-  }, [shippingInfo]);
+    validateBillingInfo();
+  }, [billingInfo]);
 
   const {
     first_name,
     surname,
-    email,
-    phone,
-    additional_info,
+    company_name,
+    company_id,
+    vat_number,
     street,
     city,
     postal_code,
     country,
-  } = shippingInfo;
+  } = billingInfo;
 
   return (
-    <div className="shipping-info-form">
-      <h2>Shipping information</h2>
+    <div className="billing-info-form">
+      <h2>Billing information</h2>
       <form>
         <TextField
           id="first-name"
@@ -300,50 +284,48 @@ const ShippingInfoForm = (props: IShippingInfoFormComponentProps) => {
           helperText={!surname.isValid ? surname.errorMessage : ""}
         />
         <TextField
-          id="email"
-          label={email.label}
+          id="company-name"
+          label={company_name.label}
           variant="outlined"
-          value={email.value}
+          value={company_name.value}
           onChange={(
             e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
           ) => {
-            email.setter(e.target.value);
-            if (email.validator && email.setIsValid) {
-              email.setIsValid(email.validator(e.target.value));
+            company_name.setter(e.target.value);
+            if (company_name.validator && company_name.setIsValid) {
+              company_name.setIsValid(company_name.validator(e.target.value));
             }
           }}
-          error={email.isValid === false}
-          helperText={!email.isValid ? email.errorMessage : ""}
+          error={company_name.isValid === false}
+          helperText={!company_name.isValid ? company_name.errorMessage : ""}
         />
         <TextField
-          id="phone"
-          label={phone.label}
+          id="company-id"
+          label={company_id.label}
           variant="outlined"
-          value={phone.value}
+          value={company_id.value}
           onChange={(
             e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
           ) => {
-            phone.setter(e.target.value);
-            if (phone.validator && phone.setIsValid) {
-              phone.setIsValid(phone.validator(e.target.value));
+            company_id.setter(e.target.value);
+            if (company_id.validator && company_id.setIsValid) {
+              company_id.setIsValid(company_id.validator(e.target.value));
             }
           }}
-          error={phone.isValid === false}
-          helperText={!phone.isValid ? phone.errorMessage : ""}
+          error={company_id.isValid === false}
+          helperText={!company_id.isValid ? company_id.errorMessage : ""}
         />
         <TextField
-          id="additional-info"
-          label={additional_info.label}
+          id="vat-number"
+          label={vat_number.label}
           variant="outlined"
-          value={additional_info.value}
+          value={vat_number.value}
           onChange={(
             e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
           ) => {
-            additional_info.setter(e.target.value);
-            if (additional_info.validator && additional_info.setIsValid) {
-              additional_info.setIsValid(
-                additional_info.validator(e.target.value)
-              );
+            vat_number.setter(e.target.value);
+            if (vat_number.validator && vat_number.setIsValid) {
+              vat_number.setIsValid(vat_number.validator(e.target.value));
             }
           }}
         />
@@ -411,4 +393,4 @@ const ShippingInfoForm = (props: IShippingInfoFormComponentProps) => {
   );
 };
 
-export default ShippingInfoForm;
+export default BillingInfoForm;

--- a/src/storefront/components/Forms/BillingInfoForm.tsx
+++ b/src/storefront/components/Forms/BillingInfoForm.tsx
@@ -43,6 +43,9 @@ export const exportBillingInfo = (
   };
 };
 
+const validateInitialState = (value: string) =>
+  value !== "" && value !== undefined;
+
 export const billingInfoInitialData = (
   billingInfo: IBillingInfo,
   setter: Dispatch<SetStateAction<IBillingInfoFormProps>>
@@ -55,7 +58,7 @@ export const billingInfoInitialData = (
   return {
     first_name: {
       value: billingInfo.first_name,
-      isValid: billingInfo.first_name != "" ? true : undefined,
+      isValid: validateInitialState(billingInfo.first_name) ? true : undefined,
       setIsValid: (value: boolean) =>
         setter((prevState) => ({
           ...prevState,
@@ -73,7 +76,7 @@ export const billingInfoInitialData = (
     },
     surname: {
       value: billingInfo.surname,
-      isValid: billingInfo.surname != "" ? true : undefined,
+      isValid: validateInitialState(billingInfo.surname) ? true : undefined,
       setIsValid: (value: boolean) =>
         setter((prevState) => ({
           ...prevState,
@@ -124,7 +127,7 @@ export const billingInfoInitialData = (
     },
     street: {
       value: billingInfo.street,
-      isValid: billingInfo.street != "" ? true : undefined,
+      isValid: validateInitialState(billingInfo.street) ? true : undefined,
       setIsValid: (value: boolean) =>
         setter((prevState) => ({
           ...prevState,
@@ -142,7 +145,7 @@ export const billingInfoInitialData = (
     },
     city: {
       value: billingInfo.city,
-      isValid: billingInfo.city != "" ? true : undefined,
+      isValid: validateInitialState(billingInfo.city) ? true : undefined,
       setIsValid: (value: boolean) =>
         setter((prevState) => ({
           ...prevState,
@@ -160,7 +163,7 @@ export const billingInfoInitialData = (
     },
     postal_code: {
       value: billingInfo.postal_code,
-      isValid: billingInfo.postal_code != "" ? true : undefined,
+      isValid: validateInitialState(billingInfo.postal_code) ? true : undefined,
       setIsValid: (value: boolean) =>
         setter((prevState) => ({
           ...prevState,
@@ -199,10 +202,11 @@ export const billingInfoInitialData = (
 
 interface IBillingInfoFormComponentProps extends IBillingInfoFormProps {
   setIsFormValid: (value: boolean) => void;
+  radioType?: "NEW" | "SAMEASSHIPPING";
 }
 
 const BillingInfoForm = (props: IBillingInfoFormComponentProps) => {
-  const { setIsFormValid, ...billingInfo } = props;
+  const { setIsFormValid, radioType, ...billingInfo } = props;
 
   /**
    * Purpose of this component is to display the billing information form
@@ -222,10 +226,19 @@ const BillingInfoForm = (props: IBillingInfoFormComponentProps) => {
    * And all done in MUI with validation.
    * */
 
+  useEffect(() => {
+    if (radioType == "SAMEASSHIPPING") {
+      setIsFormValid(true);
+    } else {
+      validateBillingInfo();
+    }
+  }, [radioType]);
+
   const validateBillingInfo = useCallback(() => {
     // iterate through the billing info and check if all the fields are valid if they're required
     const billingInfoValues: IValidatedInputField[] =
       Object.values(billingInfo);
+    console.log("billingInfoValues", billingInfoValues);
     for (let i = 0; i < billingInfoValues.length; i++) {
       const value = billingInfoValues[i];
       if (

--- a/src/storefront/components/Forms/BillingInfoForm.tsx
+++ b/src/storefront/components/Forms/BillingInfoForm.tsx
@@ -22,6 +22,27 @@ export interface IBillingInfoFormProps {
   country: IValidatedInputField;
 }
 
+export const exportBillingInfo = (
+  billingInfo: IBillingInfoFormProps
+): IBillingInfo => {
+  /**
+   * Purpose of this function is to take the billing info from the BillingInfoForm component
+   * and convert it into the format that the API expects.
+   * */
+
+  return {
+    first_name: billingInfo.first_name.value,
+    surname: billingInfo.surname.value,
+    company_name: billingInfo.company_name.value,
+    company_id: billingInfo.company_id.value,
+    vat_number: billingInfo.vat_number.value,
+    street: billingInfo.street.value,
+    city: billingInfo.city.value,
+    postal_code: billingInfo.postal_code.value,
+    country: billingInfo.country.value,
+  };
+};
+
 export const billingInfoInitialData = (
   billingInfo: IBillingInfo,
   setter: Dispatch<SetStateAction<IBillingInfoFormProps>>
@@ -74,7 +95,7 @@ export const billingInfoInitialData = (
       setter: (value: string) =>
         setter((prevState) => ({
           ...prevState,
-          email: { ...prevState.company_name, value },
+          company_name: { ...prevState.company_name, value },
         })),
       isRequired: false,
       label: "Company name",
@@ -96,7 +117,7 @@ export const billingInfoInitialData = (
       setter: (value: string) =>
         setter((prevState) => ({
           ...prevState,
-          email: { ...prevState.vat_number, value },
+          vat_number: { ...prevState.vat_number, value },
         })),
       isRequired: false,
       label: "VAT ID",
@@ -239,20 +260,17 @@ const BillingInfoForm = (props: IBillingInfoFormComponentProps) => {
   } = billingInfo;
 
   return (
-    <div className="billing-info-form">
-      <h2>Billing information</h2>
-      <form>
-        <BasicField field={first_name} />
-        <BasicField field={surname} />
-        <BasicField field={company_name} />
-        <BasicField field={company_id} />
-        <BasicField field={vat_number} />
-        <BasicField field={street} />
-        <BasicField field={city} />
-        <BasicField field={postal_code} />
-        <BasicField field={country} />
-      </form>
-    </div>
+    <form>
+      <BasicField field={first_name} />
+      <BasicField field={surname} />
+      <BasicField field={company_name} />
+      <BasicField field={company_id} />
+      <BasicField field={vat_number} />
+      <BasicField field={street} />
+      <BasicField field={city} />
+      <BasicField field={postal_code} />
+      <BasicField field={country} />
+    </form>
   );
 };
 

--- a/src/storefront/components/Forms/ShippingInfoForm.tsx
+++ b/src/storefront/components/Forms/ShippingInfoForm.tsx
@@ -200,6 +200,22 @@ interface IShippingInfoFormComponentProps extends IShippingInfoFormProps {
   setIsFormValid: (value: boolean) => void;
 }
 
+export const exportShippingInfo = (
+  shippingInfo: IShippingInfoFormProps
+): IShippingInfo => {
+  return {
+    first_name: shippingInfo.first_name.value,
+    surname: shippingInfo.surname.value,
+    email: shippingInfo.email.value,
+    phone: shippingInfo.phone.value,
+    additional_info: shippingInfo.additional_info.value,
+    street: shippingInfo.street.value,
+    city: shippingInfo.city.value,
+    postal_code: shippingInfo.postal_code.value,
+    country: shippingInfo.country.value,
+  };
+};
+
 const ShippingInfoForm = (props: IShippingInfoFormComponentProps) => {
   const { setIsFormValid, ...shippingInfo } = props;
 
@@ -259,20 +275,17 @@ const ShippingInfoForm = (props: IShippingInfoFormComponentProps) => {
   } = shippingInfo;
 
   return (
-    <div className="shipping-info-form">
-      <h2>Shipping information</h2>
-      <form>
-        <BasicField field={first_name} />
-        <BasicField field={surname} />
-        <BasicField field={email} />
-        <BasicField field={phone} />
-        <BasicField field={additional_info} />
-        <BasicField field={street} />
-        <BasicField field={city} />
-        <BasicField field={postal_code} />
-        <BasicField field={country} />
-      </form>
-    </div>
+    <form>
+      <BasicField field={first_name} />
+      <BasicField field={surname} />
+      <BasicField field={email} />
+      <BasicField field={phone} />
+      <BasicField field={additional_info} />
+      <BasicField field={street} />
+      <BasicField field={city} />
+      <BasicField field={postal_code} />
+      <BasicField field={country} />
+    </form>
   );
 };
 

--- a/src/storefront/components/Forms/ShippingInfoForm.tsx
+++ b/src/storefront/components/Forms/ShippingInfoForm.tsx
@@ -103,7 +103,10 @@ export const shippingInfoInitialData = (
           ...prevState,
           phone: { ...prevState.phone, value },
         })),
-      validator: (value: string) => value.length > 0,
+      validator: (value: string) => {
+        const phoneRegex = /^\d+$/;
+        return phoneRegex.test(value);
+      },
       isRequired: true,
       errorMessage: "Phone is required",
       label: "Phone",

--- a/src/storefront/components/Forms/ShippingInfoForm.tsx
+++ b/src/storefront/components/Forms/ShippingInfoForm.tsx
@@ -1,0 +1,414 @@
+import { IShippingInfo } from "@/types/cart";
+import TextField from "@mui/material/TextField";
+import {
+  ChangeEvent,
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+} from "react";
+
+export interface IValidatedInputField {
+  value: string;
+  isValid?: boolean;
+  setter: (value: string) => void;
+  setIsValid?: (value: boolean) => void;
+  validator?: (value: string) => boolean;
+  isRequired?: boolean;
+  errorMessage?: string;
+  label?: string;
+}
+
+export interface IShippingInfoFormProps {
+  first_name: IValidatedInputField;
+  surname: IValidatedInputField;
+  email: IValidatedInputField;
+  phone: IValidatedInputField;
+  additional_info: IValidatedInputField;
+  street: IValidatedInputField;
+  city: IValidatedInputField;
+  postal_code: IValidatedInputField;
+  country: IValidatedInputField;
+}
+
+export const shippingInfoInitialData = (
+  shippingInfo: IShippingInfo,
+  setter: Dispatch<SetStateAction<IShippingInfoFormProps>>
+): IShippingInfoFormProps => {
+  /**
+   * Purpose of this function is to take the shipping info from the API and
+   * convert it into the format that the ShippingInfoForm component expects.
+   * */
+
+  return {
+    first_name: {
+      value: shippingInfo.first_name,
+      isValid: shippingInfo.first_name != "" ? true : undefined,
+      setIsValid: (value: boolean) =>
+        setter((prevState) => ({
+          ...prevState,
+          first_name: { ...prevState.first_name, isValid: value },
+        })),
+      setter: (value: string) =>
+        setter((prevState) => ({
+          ...prevState,
+          first_name: { ...prevState.first_name, value },
+        })),
+      validator: (value: string) => value.length > 0,
+      isRequired: true,
+      errorMessage: "First name is required",
+      label: "First name",
+    },
+    surname: {
+      value: shippingInfo.surname,
+      isValid: shippingInfo.surname != "" ? true : undefined,
+      setIsValid: (value: boolean) =>
+        setter((prevState) => ({
+          ...prevState,
+          surname: { ...prevState.surname, isValid: value },
+        })),
+      setter: (value: string) =>
+        setter((prevState) => ({
+          ...prevState,
+          surname: { ...prevState.surname, value },
+        })),
+      validator: (value: string) => value.length > 0,
+      isRequired: true,
+      errorMessage: "Surname is required",
+      label: "Surname",
+    },
+    email: {
+      value: shippingInfo.email,
+      isValid: shippingInfo.email != "" ? true : undefined,
+      setIsValid: (value: boolean) =>
+        setter((prevState) => ({
+          ...prevState,
+          email: { ...prevState.email, isValid: value },
+        })),
+      setter: (value: string) =>
+        setter((prevState) => ({
+          ...prevState,
+          email: { ...prevState.email, value },
+        })),
+      validator: (value: string) => {
+        const emailRegex = /\S+@\S+\.\S+/;
+        return emailRegex.test(value);
+      },
+      isRequired: true,
+      errorMessage: "Email is required",
+      label: "Email",
+    },
+    phone: {
+      value: shippingInfo.phone,
+      isValid: shippingInfo.phone != "" ? true : undefined,
+      setIsValid: (value: boolean) =>
+        setter((prevState) => ({
+          ...prevState,
+          phone: { ...prevState.phone, isValid: value },
+        })),
+      setter: (value: string) =>
+        setter((prevState) => ({
+          ...prevState,
+          phone: { ...prevState.phone, value },
+        })),
+      validator: (value: string) => value.length > 0,
+      isRequired: true,
+      errorMessage: "Phone is required",
+      label: "Phone",
+    },
+    additional_info: {
+      value: shippingInfo.additional_info,
+      setter: (value: string) =>
+        setter((prevState) => ({
+          ...prevState,
+          additional_info: { ...prevState.additional_info, value },
+        })),
+      isRequired: false,
+      label: "Additional info",
+    },
+    street: {
+      value: shippingInfo.street,
+      isValid: shippingInfo.street != "" ? true : undefined,
+      setIsValid: (value: boolean) =>
+        setter((prevState) => ({
+          ...prevState,
+          street: { ...prevState.street, isValid: value },
+        })),
+      setter: (value: string) =>
+        setter((prevState) => ({
+          ...prevState,
+          street: { ...prevState.street, value },
+        })),
+      validator: (value: string) => value.length > 0,
+      isRequired: true,
+      errorMessage: "Street is required",
+      label: "Street",
+    },
+    city: {
+      value: shippingInfo.city,
+      isValid: shippingInfo.city != "" ? true : undefined,
+      setIsValid: (value: boolean) =>
+        setter((prevState) => ({
+          ...prevState,
+          city: { ...prevState.city, isValid: value },
+        })),
+      setter: (value: string) =>
+        setter((prevState) => ({
+          ...prevState,
+          city: { ...prevState.city, value },
+        })),
+      validator: (value: string) => value.length > 0,
+      isRequired: true,
+      errorMessage: "City is required",
+      label: "City",
+    },
+    postal_code: {
+      value: shippingInfo.postal_code,
+      isValid: shippingInfo.postal_code != "" ? true : undefined,
+      setIsValid: (value: boolean) =>
+        setter((prevState) => ({
+          ...prevState,
+          postal_code: { ...prevState.postal_code, isValid: value },
+        })),
+      setter: (value: string) =>
+        setter((prevState) => ({
+          ...prevState,
+          postal_code: { ...prevState.postal_code, value },
+        })),
+      validator: (value: string) => value.length > 0,
+      isRequired: true,
+      errorMessage: "Postal code is required",
+      label: "Postal code",
+    },
+    country: {
+      value: `${shippingInfo.country}`,
+      isValid: `${shippingInfo.country}` != "" ? true : undefined,
+      setIsValid: (value: boolean) =>
+        setter((prevState) => ({
+          ...prevState,
+          country: { ...prevState.country, isValid: value },
+        })),
+      setter: (value: string) =>
+        setter((prevState) => ({
+          ...prevState,
+          country: { ...prevState.country, value },
+        })),
+      validator: (value: string) => value.length > 0,
+      isRequired: true,
+      errorMessage: "Country is required",
+      label: "Country",
+    },
+  };
+};
+
+interface IShippingInfoFormComponentProps extends IShippingInfoFormProps {
+  setIsFormValid: (value: boolean) => void;
+}
+
+const ShippingInfoForm = (props: IShippingInfoFormComponentProps) => {
+  const { setIsFormValid, ...shippingInfo } = props;
+
+  /**
+   * Purpose of this component is to display the shipping information form
+   * and have it be pre-populated with the shipping information if it exists.
+   *
+   * It should be a form with header "Shipping information" and the following fields:
+   * - First name
+   * - Surname
+   * - Email
+   * - Phone
+   * - Additional info (optional)
+   * - Street
+   * - City
+   * - Postal code
+   * - Country
+   *
+   * And all done in MUI with validation.
+   * */
+
+  const validateShippingInfo = useCallback(() => {
+    // iterate through the shipping info and check if all the fields are valid if they're required
+    const shippingInfoValues: IValidatedInputField[] =
+      Object.values(shippingInfo);
+    for (let i = 0; i < shippingInfoValues.length; i++) {
+      const value = shippingInfoValues[i];
+      if (
+        value.isRequired &&
+        (value.isValid == false || value.isValid == undefined)
+      ) {
+        setIsFormValid(false);
+        return;
+      }
+    }
+    if (shippingInfoValues.length === 0) {
+      setIsFormValid(false);
+      return;
+    }
+    setIsFormValid(true);
+  }, [shippingInfo]);
+
+  useEffect(() => {
+    validateShippingInfo();
+  }, [shippingInfo]);
+
+  const {
+    first_name,
+    surname,
+    email,
+    phone,
+    additional_info,
+    street,
+    city,
+    postal_code,
+    country,
+  } = shippingInfo;
+
+  return (
+    <div className="shipping-info-form">
+      <h2>Shipping information</h2>
+      <form>
+        <TextField
+          id="first-name"
+          label={first_name.label}
+          variant="outlined"
+          value={first_name.value}
+          onChange={(
+            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+          ) => {
+            first_name.setter(e.target.value);
+            if (first_name.validator && first_name.setIsValid) {
+              first_name.setIsValid(first_name.validator(e.target.value));
+            }
+          }}
+          error={first_name.isValid === false}
+          helperText={!first_name.isValid ? first_name.errorMessage : ""}
+        />
+        <TextField
+          id="surname"
+          label="Surname"
+          variant="outlined"
+          value={surname.value}
+          onChange={(
+            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+          ) => {
+            surname.setter(e.target.value);
+            if (surname.validator && surname.setIsValid) {
+              surname.setIsValid(surname.validator(e.target.value));
+            }
+          }}
+          error={surname.isValid === false}
+          helperText={!surname.isValid ? surname.errorMessage : ""}
+        />
+        <TextField
+          id="email"
+          label="Email"
+          variant="outlined"
+          value={email.value}
+          onChange={(
+            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+          ) => {
+            email.setter(e.target.value);
+            if (email.validator && email.setIsValid) {
+              email.setIsValid(email.validator(e.target.value));
+            }
+          }}
+          error={email.isValid === false}
+          helperText={!email.isValid ? email.errorMessage : ""}
+        />
+        <TextField
+          id="phone"
+          label={phone.label}
+          variant="outlined"
+          value={phone.value}
+          onChange={(
+            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+          ) => {
+            phone.setter(e.target.value);
+            if (phone.validator && phone.setIsValid) {
+              phone.setIsValid(phone.validator(e.target.value));
+            }
+          }}
+          error={phone.isValid === false}
+          helperText={!phone.isValid ? phone.errorMessage : ""}
+        />
+        <TextField
+          id="additional-info"
+          label={additional_info.label}
+          variant="outlined"
+          value={additional_info.value}
+          onChange={(
+            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+          ) => {
+            additional_info.setter(e.target.value);
+            if (additional_info.validator && additional_info.setIsValid) {
+              additional_info.setIsValid(
+                additional_info.validator(e.target.value)
+              );
+            }
+          }}
+        />
+        <TextField
+          id="street"
+          label={street.label}
+          variant="outlined"
+          value={street.value}
+          onChange={(
+            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+          ) => {
+            street.setter(e.target.value);
+            if (street.validator && street.setIsValid) {
+              street.setIsValid(street.validator(e.target.value));
+            }
+          }}
+          error={street.isValid === false}
+          helperText={!street.isValid ? street.errorMessage : ""}
+        />
+        <TextField
+          id="city"
+          label={city.label}
+          variant="outlined"
+          value={city.value}
+          onChange={(
+            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+          ) => {
+            city.setter(e.target.value);
+            if (city.validator && city.setIsValid) {
+              city.setIsValid(city.validator(e.target.value));
+            }
+          }}
+          error={city.isValid === false}
+          helperText={!city.isValid ? city.errorMessage : ""}
+        />
+        <TextField
+          id="postal-code"
+          label={postal_code.label}
+          variant="outlined"
+          value={postal_code.value}
+          onChange={(
+            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+          ) => {
+            postal_code.setter(e.target.value);
+            if (postal_code.validator && postal_code.setIsValid) {
+              postal_code.setIsValid(postal_code.validator(e.target.value));
+            }
+          }}
+          error={postal_code.isValid === false}
+          helperText={!postal_code.isValid ? postal_code.errorMessage : ""}
+        />
+        <TextField
+          id="country"
+          label={country.label}
+          variant="outlined"
+          value={country.value}
+          onChange={(e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) =>
+            country.setter(e.target.value)
+          }
+          error={country.isValid === false}
+          helperText={!country.isValid ? country.errorMessage : ""}
+        />
+      </form>
+    </div>
+  );
+};
+
+export default ShippingInfoForm;

--- a/src/storefront/components/Forms/ShippingInfoForm.tsx
+++ b/src/storefront/components/Forms/ShippingInfoForm.tsx
@@ -1,4 +1,5 @@
 import { IShippingInfo } from "@/types/cart";
+import { IValidatedInputField } from "@/types/common";
 import TextField from "@mui/material/TextField";
 import {
   ChangeEvent,
@@ -7,17 +8,8 @@ import {
   useCallback,
   useEffect,
 } from "react";
-
-export interface IValidatedInputField {
-  value: string;
-  isValid?: boolean;
-  setter: (value: string) => void;
-  setIsValid?: (value: boolean) => void;
-  validator?: (value: string) => boolean;
-  isRequired?: boolean;
-  errorMessage?: string;
-  label?: string;
-}
+import BasicFields from "./BasicField";
+import BasicField from "./BasicField";
 
 export interface IShippingInfoFormProps {
   first_name: IValidatedInputField;
@@ -267,145 +259,15 @@ const ShippingInfoForm = (props: IShippingInfoFormComponentProps) => {
     <div className="shipping-info-form">
       <h2>Shipping information</h2>
       <form>
-        <TextField
-          id="first-name"
-          label={first_name.label}
-          variant="outlined"
-          value={first_name.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            first_name.setter(e.target.value);
-            if (first_name.validator && first_name.setIsValid) {
-              first_name.setIsValid(first_name.validator(e.target.value));
-            }
-          }}
-          error={first_name.isValid === false}
-          helperText={!first_name.isValid ? first_name.errorMessage : ""}
-        />
-        <TextField
-          id="surname"
-          label="Surname"
-          variant="outlined"
-          value={surname.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            surname.setter(e.target.value);
-            if (surname.validator && surname.setIsValid) {
-              surname.setIsValid(surname.validator(e.target.value));
-            }
-          }}
-          error={surname.isValid === false}
-          helperText={!surname.isValid ? surname.errorMessage : ""}
-        />
-        <TextField
-          id="email"
-          label={email.label}
-          variant="outlined"
-          value={email.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            email.setter(e.target.value);
-            if (email.validator && email.setIsValid) {
-              email.setIsValid(email.validator(e.target.value));
-            }
-          }}
-          error={email.isValid === false}
-          helperText={!email.isValid ? email.errorMessage : ""}
-        />
-        <TextField
-          id="phone"
-          label={phone.label}
-          variant="outlined"
-          value={phone.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            phone.setter(e.target.value);
-            if (phone.validator && phone.setIsValid) {
-              phone.setIsValid(phone.validator(e.target.value));
-            }
-          }}
-          error={phone.isValid === false}
-          helperText={!phone.isValid ? phone.errorMessage : ""}
-        />
-        <TextField
-          id="additional-info"
-          label={additional_info.label}
-          variant="outlined"
-          value={additional_info.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            additional_info.setter(e.target.value);
-            if (additional_info.validator && additional_info.setIsValid) {
-              additional_info.setIsValid(
-                additional_info.validator(e.target.value)
-              );
-            }
-          }}
-        />
-        <TextField
-          id="street"
-          label={street.label}
-          variant="outlined"
-          value={street.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            street.setter(e.target.value);
-            if (street.validator && street.setIsValid) {
-              street.setIsValid(street.validator(e.target.value));
-            }
-          }}
-          error={street.isValid === false}
-          helperText={!street.isValid ? street.errorMessage : ""}
-        />
-        <TextField
-          id="city"
-          label={city.label}
-          variant="outlined"
-          value={city.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            city.setter(e.target.value);
-            if (city.validator && city.setIsValid) {
-              city.setIsValid(city.validator(e.target.value));
-            }
-          }}
-          error={city.isValid === false}
-          helperText={!city.isValid ? city.errorMessage : ""}
-        />
-        <TextField
-          id="postal-code"
-          label={postal_code.label}
-          variant="outlined"
-          value={postal_code.value}
-          onChange={(
-            e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            postal_code.setter(e.target.value);
-            if (postal_code.validator && postal_code.setIsValid) {
-              postal_code.setIsValid(postal_code.validator(e.target.value));
-            }
-          }}
-          error={postal_code.isValid === false}
-          helperText={!postal_code.isValid ? postal_code.errorMessage : ""}
-        />
-        <TextField
-          id="country"
-          label={country.label}
-          variant="outlined"
-          value={country.value}
-          onChange={(e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) =>
-            country.setter(e.target.value)
-          }
-          error={country.isValid === false}
-          helperText={!country.isValid ? country.errorMessage : ""}
-        />
+        <BasicField field={first_name} />
+        <BasicField field={surname} />
+        <BasicField field={email} />
+        <BasicField field={phone} />
+        <BasicField field={additional_info} />
+        <BasicField field={street} />
+        <BasicField field={city} />
+        <BasicField field={postal_code} />
+        <BasicField field={country} />
       </form>
     </div>
   );

--- a/src/storefront/components/Forms/ShippingInfoForm.tsx
+++ b/src/storefront/components/Forms/ShippingInfoForm.tsx
@@ -1,4 +1,4 @@
-import { IShippingInfo } from "@/types/cart";
+import { ICountryOption, IShippingInfo } from "@/types/cart";
 import { IValidatedInputField } from "@/types/common";
 import TextField from "@mui/material/TextField";
 import {
@@ -8,8 +8,9 @@ import {
   useCallback,
   useEffect,
 } from "react";
-import BasicFields from "./BasicField";
+import BasicFields, { BasicSelect, TwoFieldsOneRowWrapper } from "./BasicField";
 import BasicField from "./BasicField";
+import Grid from "@mui/material/Grid";
 
 export interface IShippingInfoFormProps {
   first_name: IValidatedInputField;
@@ -198,6 +199,8 @@ export const shippingInfoInitialData = (
 
 interface IShippingInfoFormComponentProps extends IShippingInfoFormProps {
   setIsFormValid: (value: boolean) => void;
+  countryOptions?: ICountryOption[];
+  allowCountryChange?: boolean;
 }
 
 export const exportShippingInfo = (
@@ -217,7 +220,12 @@ export const exportShippingInfo = (
 };
 
 const ShippingInfoForm = (props: IShippingInfoFormComponentProps) => {
-  const { setIsFormValid, ...shippingInfo } = props;
+  const {
+    setIsFormValid,
+    countryOptions,
+    allowCountryChange = false,
+    ...shippingInfo
+  } = props;
 
   /**
    * Purpose of this component is to display the shipping information form
@@ -241,11 +249,13 @@ const ShippingInfoForm = (props: IShippingInfoFormComponentProps) => {
     // iterate through the shipping info and check if all the fields are valid if they're required
     const shippingInfoValues: IValidatedInputField[] =
       Object.values(shippingInfo);
+    const shippingInfoKeys: string[] = Object.keys(shippingInfo);
     for (let i = 0; i < shippingInfoValues.length; i++) {
       const value = shippingInfoValues[i];
       if (
         value.isRequired &&
-        (value.isValid == false || value.isValid == undefined)
+        (value.isValid == false || value.isValid == undefined) &&
+        !(shippingInfoKeys[i] == "country" && allowCountryChange)
       ) {
         setIsFormValid(false);
         return;
@@ -276,15 +286,28 @@ const ShippingInfoForm = (props: IShippingInfoFormComponentProps) => {
 
   return (
     <form>
-      <BasicField field={first_name} />
-      <BasicField field={surname} />
+      <TwoFieldsOneRowWrapper>
+        <BasicField field={first_name} />
+        <BasicField field={surname} />
+      </TwoFieldsOneRowWrapper>
       <BasicField field={email} />
       <BasicField field={phone} />
-      <BasicField field={additional_info} />
-      <BasicField field={street} />
-      <BasicField field={city} />
-      <BasicField field={postal_code} />
-      <BasicField field={country} />
+      <TwoFieldsOneRowWrapper>
+        <BasicField field={street} />
+        <BasicField field={additional_info} />
+      </TwoFieldsOneRowWrapper>
+      <TwoFieldsOneRowWrapper>
+        <BasicField field={city} />
+        <BasicField field={postal_code} />
+      </TwoFieldsOneRowWrapper>
+
+      {countryOptions && countryOptions?.length > 0 ? (
+        <BasicSelect
+          field={country}
+          options={countryOptions}
+          disabled={!allowCountryChange}
+        />
+      ) : null}
     </form>
   );
 };

--- a/src/storefront/pages/api/cart/[token]/billing-info.ts
+++ b/src/storefront/pages/api/cart/[token]/billing-info.ts
@@ -1,0 +1,76 @@
+// /api/cart/[token]/billing-info.ts
+// call the cart billing info api in the backend and modify the cart billing info
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  api,
+  setRequestResponse,
+  backendApiHelper,
+  cartApiUrlHelper,
+} from "@/utils/interceptors/api";
+import { HTTPMETHOD } from "@/types/common";
+
+export const cartBillingInfoAPI = async (
+  method: HTTPMETHOD,
+  token: string,
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
+  if (req && res) {
+    setRequestResponse(req, res);
+  }
+
+  let url = `/cart/storefront/${token}/billing-info/`;
+
+  const { body } = req;
+
+  console.log("body", body);
+
+  switch (method) {
+    case "GET":
+      return await api
+        .get(url)
+        .then((response) => response.data)
+        .then((data) => {
+          return data;
+        })
+        .catch((error: any) => {
+          throw error;
+        });
+    case "PUT":
+      return await api
+        .put(url, body)
+        .then((response) => response.data)
+        .then((data) => {
+          return data;
+        })
+        .catch((error: any) => {
+          throw error;
+        });
+    default:
+      throw new Error("Method not supported");
+  }
+};
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  /**
+   * This is a wrapper for the cart billing info API in the backend
+   */
+  const { method } = req;
+  const { token } = req.query;
+
+  const { body } = req;
+
+  if (method == "GET") {
+    return cartBillingInfoAPI("GET", token as string, req, res)
+      .then((data) => res.status(200).json(data))
+      .catch((error) => res.status(400).json(null));
+  } else if (method == "PUT") {
+    return cartBillingInfoAPI("PUT", token as string, req, res)
+      .then((data) => res.status(201).json(data))
+      .catch((error) => res.status(400).json(null));
+  }
+
+  return res.status(404).json({ message: "Method not supported" });
+};
+
+export default handler;

--- a/src/storefront/pages/api/cart/[token]/shipping-info.ts
+++ b/src/storefront/pages/api/cart/[token]/shipping-info.ts
@@ -1,0 +1,76 @@
+// /api/cart/[token]/shipping-info.ts
+// call the cart shipping info api in the backend and modify the cart shipping info
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  api,
+  setRequestResponse,
+  backendApiHelper,
+  cartApiUrlHelper,
+} from "@/utils/interceptors/api";
+import { HTTPMETHOD } from "@/types/common";
+
+export const cartShippingInfoAPI = async (
+  method: HTTPMETHOD,
+  token: string,
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
+  if (req && res) {
+    setRequestResponse(req, res);
+  }
+
+  let url = `/cart/storefront/${token}/shipping-info/`;
+
+  const { body } = req;
+
+  console.log("body", body);
+
+  switch (method) {
+    case "GET":
+      return await api
+        .get(url)
+        .then((response) => response.data)
+        .then((data) => {
+          return data;
+        })
+        .catch((error: any) => {
+          throw error;
+        });
+    case "PUT":
+      return await api
+        .put(url, body)
+        .then((response) => response.data)
+        .then((data) => {
+          return data;
+        })
+        .catch((error: any) => {
+          throw error;
+        });
+    default:
+      throw new Error("Method not supported");
+  }
+};
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  /**
+   * This is a wrapper for the cart shipping info API in the backend
+   */
+  const { method } = req;
+  const { token } = req.query;
+
+  const { body } = req;
+
+  if (method == "GET") {
+    return cartShippingInfoAPI("GET", token as string, req, res)
+      .then((data) => res.status(200).json(data))
+      .catch((error) => res.status(400).json(null));
+  } else if (method == "PUT") {
+    return cartShippingInfoAPI("PUT", token as string, req, res)
+      .then((data) => res.status(201).json(data))
+      .catch((error) => res.status(400).json(null));
+  }
+
+  return res.status(404).json({ message: "Method not supported" });
+};
+
+export default handler;

--- a/src/storefront/pages/api/country/index.ts
+++ b/src/storefront/pages/api/country/index.ts
@@ -1,0 +1,54 @@
+// /api/country/index.ts
+// call the country api in the backend and return the data (list of countries)
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  api,
+  setRequestResponse,
+  backendApiHelper,
+  cartApiUrlHelper,
+} from "@/utils/interceptors/api";
+import { ICountry } from "@/types/country";
+import { HTTPMETHOD } from "@/types/common";
+
+export const countryListAPI = async (
+  method: HTTPMETHOD,
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
+  if (req && res) {
+    setRequestResponse(req, res);
+  }
+
+  switch (method) {
+    case "GET":
+      return await api
+        .get("/country/")
+        .then((response) => response.data)
+        .then((data: ICountry[]) => {
+          console.log("data", data);
+          return data;
+        })
+        .catch((error: any) => {
+          throw error;
+        });
+    default:
+      throw new Error("Method not supported");
+  }
+};
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  /**
+   * This is a wrapper for the country list api in the backend
+   */
+  // get the cart data from the backend
+  const method = req.method as HTTPMETHOD;
+
+  if (method === "GET") {
+    return countryListAPI("GET", req, res)
+      .then((data) => res.status(200).json(data))
+      .catch((error) => res.status(400).json(null));
+  }
+  return res.status(400).json({ message: "Method not supported" });
+};
+
+export default handler;

--- a/src/storefront/pages/cart/step/1.tsx
+++ b/src/storefront/pages/cart/step/1.tsx
@@ -1,3 +1,7 @@
+import BillingInfoForm, {
+  IBillingInfoFormProps,
+  billingInfoInitialData,
+} from "@/components/Forms/BillingInfoForm";
 import ShippingInfoForm, {
   IShippingInfoFormProps,
   shippingInfoInitialData,
@@ -31,6 +35,16 @@ const CartStep1Page = ({ shippingInfo, billingInfo }: ICartStep1PageProps) => {
     );
   }
 
+  const [validBillingInfo, setValidBillingInfo] = useState<boolean>(false);
+  const [billingInfoState, setBillingInfoState] =
+    useState<IBillingInfoFormProps>({} as IBillingInfoFormProps);
+
+  if (Object.keys(billingInfoState)?.length === 0) {
+    setBillingInfoState(
+      billingInfoInitialData(shippingInfo, setBillingInfoState)
+    );
+  }
+
   console.log("shippingInfoState", shippingInfoState);
   return (
     <div className="container">
@@ -47,6 +61,19 @@ const CartStep1Page = ({ shippingInfo, billingInfo }: ICartStep1PageProps) => {
         setIsFormValid={setValidShippingInfo}
       />
       Shipping is valid: {validShippingInfo ? "true" : "false"}
+      <BillingInfoForm
+        first_name={billingInfoState.first_name}
+        surname={billingInfoState.surname}
+        company_name={billingInfoState.company_name}
+        company_id={billingInfoState.company_id}
+        vat_number={billingInfoState.vat_number}
+        street={billingInfoState.street}
+        city={billingInfoState.city}
+        postal_code={billingInfoState.postal_code}
+        country={billingInfoState.country}
+        setIsFormValid={setValidBillingInfo}
+      />
+      Billing is valid: {validBillingInfo ? "true" : "false"}
     </div>
   );
 };

--- a/src/storefront/pages/cart/step/1.tsx
+++ b/src/storefront/pages/cart/step/1.tsx
@@ -24,6 +24,7 @@ import ShippingInfoForm, {
 } from "@/components/Forms/ShippingInfoForm";
 // mui
 import {
+  Box,
   FormControl,
   FormControlLabel,
   FormLabel,
@@ -96,6 +97,46 @@ const CartStep1Page = ({
     }
   }
 
+  const submitForm = async () => {
+    if (
+      !validShippingInfo ||
+      (!validBillingInfo && billingRadioSelect === "NEW")
+    ) {
+      return;
+    }
+    // Shipping info
+    const exportedShipping = exportShippingInfo(shippingInfoState);
+    const shippingInfoResp = await putShippingInfo(cartToken, exportedShipping);
+
+    // Billing info
+    let billingInfoResp;
+    if (billingRadioSelect === "SAMEASSHIPPING") {
+      const billingSameAsShipping = {
+        first_name: exportedShipping.first_name,
+        surname: exportedShipping.surname,
+        street: exportedShipping.street,
+        city: exportedShipping.city,
+        postal_code: exportedShipping.postal_code,
+        country: exportedShipping.country,
+        company_name: "",
+        company_id: "",
+        vat_number: "",
+      };
+      console.log("billingSameAsShipping", billingSameAsShipping);
+      billingInfoResp = await putBillingInfo(cartToken, billingSameAsShipping);
+    } else {
+      billingInfoResp = await putBillingInfo(
+        cartToken,
+        exportBillingInfo(billingInfoState)
+      );
+    }
+    console.log("shippingInfoResp", shippingInfoResp);
+    console.log("billingInfoResp", billingInfoResp);
+    if (shippingInfoResp === 201 && billingInfoResp === 201) {
+      router.push("/cart/step/2");
+    }
+  };
+
   console.log("shippingInfoState", shippingInfoState);
   return (
     <div className="container">
@@ -167,68 +208,39 @@ const CartStep1Page = ({
           Billing is valid: {validBillingInfo ? "true" : "false"}
         </Grid>
       </Grid>
-      <Typography
-        variant="h4"
-        onClick={() => {
-          router.push("/cart");
-        }}
+      <Box
+        component="span"
+        m={1}
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
       >
-        Back to cart
-      </Typography>
-      <Button
-        variant={"contained"}
-        disabled={
-          !validShippingInfo ||
-          (!validBillingInfo && billingRadioSelect === "NEW")
-        }
-        onClick={async () => {
-          if (
+        <Typography
+          variant="body1"
+          sx={{
+            cursor: "pointer",
+            textDecoration: "underline",
+            "&:hover": {
+              color: "primary.main",
+            },
+          }}
+          onClick={() => {
+            router.push("/cart");
+          }}
+        >
+          Back to cart
+        </Typography>
+        <Button
+          variant={"contained"}
+          disabled={
             !validShippingInfo ||
             (!validBillingInfo && billingRadioSelect === "NEW")
-          ) {
-            return;
           }
-          // Shipping info
-          const exportedShipping = exportShippingInfo(shippingInfoState);
-          const shippingInfoResp = await putShippingInfo(
-            cartToken,
-            exportedShipping
-          );
-
-          // Billing info
-          let billingInfoResp;
-          if (billingRadioSelect === "SAMEASSHIPPING") {
-            const billingSameAsShipping = {
-              first_name: exportedShipping.first_name,
-              surname: exportedShipping.surname,
-              street: exportedShipping.street,
-              city: exportedShipping.city,
-              postal_code: exportedShipping.postal_code,
-              country: exportedShipping.country,
-              company_name: "",
-              company_id: "",
-              vat_number: "",
-            };
-            console.log("billingSameAsShipping", billingSameAsShipping);
-            billingInfoResp = await putBillingInfo(
-              cartToken,
-              billingSameAsShipping
-            );
-          } else {
-            billingInfoResp = await putBillingInfo(
-              cartToken,
-              exportBillingInfo(billingInfoState)
-            );
-          }
-          console.log("shippingInfoResp", shippingInfoResp);
-          console.log("billingInfoResp", billingInfoResp);
-          if (shippingInfoResp === 201 && billingInfoResp === 201) {
-            router.push("/cart/step/2");
-          }
-        }}
-      >
-        Next
-      </Button>
+          onClick={async () => submitForm()}
+        >
+          Next
+        </Button>
+      </Box>
     </div>
   );
 };

--- a/src/storefront/pages/cart/step/1.tsx
+++ b/src/storefront/pages/cart/step/1.tsx
@@ -1,31 +1,59 @@
-import BillingInfoForm, {
-  IBillingInfoFormProps,
-  billingInfoInitialData,
-} from "@/components/Forms/BillingInfoForm";
-import ShippingInfoForm, {
-  IShippingInfoFormProps,
-  shippingInfoInitialData,
-} from "@/components/Forms/ShippingInfoForm";
+// next
+import { GetServerSideProps, NextApiRequest, NextApiResponse } from "next";
+import { useRouter } from "next/router";
+
+// react
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+// api
+import { putBillingInfo, putShippingInfo } from "@/api/cart/info";
 import { cartAPI } from "@/pages/api/cart/[token]";
 import { cartBillingInfoAPI } from "@/pages/api/cart/[token]/billing-info";
 import { cartShippingInfoAPI } from "@/pages/api/cart/[token]/shipping-info";
-import { IBillingInfo, IShippingInfo } from "@/types/cart";
+
+// components
+import BillingInfoForm, {
+  IBillingInfoFormProps,
+  billingInfoInitialData,
+  exportBillingInfo,
+} from "@/components/Forms/BillingInfoForm";
+import ShippingInfoForm, {
+  IShippingInfoFormProps,
+  exportShippingInfo,
+  shippingInfoInitialData,
+} from "@/components/Forms/ShippingInfoForm";
+// mui
+import {
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from "@mui/material";
+import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
-import { GetServerSideProps, NextApiRequest, NextApiResponse } from "next";
-import { useCallback, useEffect, useMemo, useState } from "react";
+// types
+import { IBillingInfo, IShippingInfo } from "@/types/cart";
 
 interface ICartStep1PageProps {
   shippingInfo: any;
   billingInfo: any;
+  cartToken: string;
 }
 
-const CartStep1Page = ({ shippingInfo, billingInfo }: ICartStep1PageProps) => {
+const CartStep1Page = ({
+  shippingInfo,
+  billingInfo,
+  cartToken,
+}: ICartStep1PageProps) => {
   /**
    * Step 1 page of the cart consist of the:
    * - shipping info
    * - billing info
    */
 
+  const router = useRouter();
   const [validShippingInfo, setValidShippingInfo] = useState<boolean>(false);
   const [shippingInfoState, setShippingInfoState] =
     useState<IShippingInfoFormProps>({} as IShippingInfoFormProps);
@@ -36,14 +64,36 @@ const CartStep1Page = ({ shippingInfo, billingInfo }: ICartStep1PageProps) => {
     );
   }
 
+  const [billingRadioSelect, setBillingRadioSelect] = useState<
+    "SAMEASSHIPPING" | "NEW"
+  >("SAMEASSHIPPING");
   const [validBillingInfo, setValidBillingInfo] = useState<boolean>(false);
   const [billingInfoState, setBillingInfoState] =
     useState<IBillingInfoFormProps>({} as IBillingInfoFormProps);
 
   if (Object.keys(billingInfoState)?.length === 0) {
-    setBillingInfoState(
-      billingInfoInitialData(shippingInfo, setBillingInfoState)
-    );
+    // on first load check if the billing info is the same as the shipping info
+    if (
+      shippingInfo.first_name === billingInfo.first_name &&
+      shippingInfo.surname === billingInfo.surname &&
+      shippingInfo.street === billingInfo.street &&
+      shippingInfo.city === billingInfo.city &&
+      shippingInfo.postal_code === billingInfo.postal_code &&
+      shippingInfo.country === billingInfo.country &&
+      !billingInfo.company_name &&
+      !billingInfo.company_id &&
+      !billingInfo.vat_number
+    ) {
+      setBillingRadioSelect("SAMEASSHIPPING");
+      setBillingInfoState(
+        billingInfoInitialData({} as IBillingInfo, setBillingInfoState)
+      );
+    } else {
+      setBillingRadioSelect("NEW");
+      setBillingInfoState(
+        billingInfoInitialData(billingInfo, setBillingInfoState)
+      );
+    }
   }
 
   console.log("shippingInfoState", shippingInfoState);
@@ -55,36 +105,130 @@ const CartStep1Page = ({ shippingInfo, billingInfo }: ICartStep1PageProps) => {
         columns={{ xs: 4, sm: 8, md: 12 }}
       >
         <Grid container item xs={2} sm={4} md={4} direction="column">
-          <ShippingInfoForm
-            first_name={shippingInfoState.first_name}
-            surname={shippingInfoState.surname}
-            email={shippingInfoState.email}
-            phone={shippingInfoState.phone}
-            additional_info={shippingInfoState.additional_info}
-            street={shippingInfoState.street}
-            city={shippingInfoState.city}
-            postal_code={shippingInfoState.postal_code}
-            country={shippingInfoState.country}
-            setIsFormValid={setValidShippingInfo}
-          />
+          <div className="shipping-info-form">
+            <h2>Shipping information</h2>
+            <ShippingInfoForm
+              first_name={shippingInfoState.first_name}
+              surname={shippingInfoState.surname}
+              email={shippingInfoState.email}
+              phone={shippingInfoState.phone}
+              additional_info={shippingInfoState.additional_info}
+              street={shippingInfoState.street}
+              city={shippingInfoState.city}
+              postal_code={shippingInfoState.postal_code}
+              country={shippingInfoState.country}
+              setIsFormValid={setValidShippingInfo}
+            />
+          </div>
           Shipping is valid: {validShippingInfo ? "true" : "false"}
         </Grid>
         <Grid container item xs={2} sm={4} md={4} direction="column">
-          <BillingInfoForm
-            first_name={billingInfoState.first_name}
-            surname={billingInfoState.surname}
-            company_name={billingInfoState.company_name}
-            company_id={billingInfoState.company_id}
-            vat_number={billingInfoState.vat_number}
-            street={billingInfoState.street}
-            city={billingInfoState.city}
-            postal_code={billingInfoState.postal_code}
-            country={billingInfoState.country}
-            setIsFormValid={setValidBillingInfo}
-          />
+          <div className="billing-info-form">
+            <h2>Billing information</h2>
+            <FormControl>
+              <RadioGroup
+                defaultValue="SAMEASSHIPPING"
+                value={billingRadioSelect}
+                name="radio-buttons-billing-info-group"
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setBillingRadioSelect(
+                    event.target.value as "SAMEASSHIPPING" | "NEW"
+                  );
+                }}
+              >
+                <FormControlLabel
+                  value="SAMEASSHIPPING"
+                  control={<Radio />}
+                  label="Same as shipping info"
+                />
+                <FormControlLabel
+                  value="NEW"
+                  control={<Radio />}
+                  label="New billing info"
+                />
+              </RadioGroup>
+            </FormControl>
+
+            {billingRadioSelect === "SAMEASSHIPPING" ? null : (
+              <BillingInfoForm
+                first_name={billingInfoState.first_name}
+                surname={billingInfoState.surname}
+                company_name={billingInfoState.company_name}
+                company_id={billingInfoState.company_id}
+                vat_number={billingInfoState.vat_number}
+                street={billingInfoState.street}
+                city={billingInfoState.city}
+                postal_code={billingInfoState.postal_code}
+                country={billingInfoState.country}
+                setIsFormValid={setValidBillingInfo}
+              />
+            )}
+          </div>
           Billing is valid: {validBillingInfo ? "true" : "false"}
         </Grid>
       </Grid>
+      <Typography
+        variant="h4"
+        onClick={() => {
+          router.push("/cart");
+        }}
+      >
+        Back to cart
+      </Typography>
+      <Button
+        variant={"contained"}
+        disabled={
+          !validShippingInfo ||
+          (!validBillingInfo && billingRadioSelect === "NEW")
+        }
+        onClick={async () => {
+          if (
+            !validShippingInfo ||
+            (!validBillingInfo && billingRadioSelect === "NEW")
+          ) {
+            return;
+          }
+          // Shipping info
+          const exportedShipping = exportShippingInfo(shippingInfoState);
+          const shippingInfoResp = await putShippingInfo(
+            cartToken,
+            exportedShipping
+          );
+
+          // Billing info
+          let billingInfoResp;
+          if (billingRadioSelect === "SAMEASSHIPPING") {
+            const billingSameAsShipping = {
+              first_name: exportedShipping.first_name,
+              surname: exportedShipping.surname,
+              street: exportedShipping.street,
+              city: exportedShipping.city,
+              postal_code: exportedShipping.postal_code,
+              country: exportedShipping.country,
+              company_name: "",
+              company_id: "",
+              vat_number: "",
+            };
+            console.log("billingSameAsShipping", billingSameAsShipping);
+            billingInfoResp = await putBillingInfo(
+              cartToken,
+              billingSameAsShipping
+            );
+          } else {
+            billingInfoResp = await putBillingInfo(
+              cartToken,
+              exportBillingInfo(billingInfoState)
+            );
+          }
+          console.log("shippingInfoResp", shippingInfoResp);
+          console.log("billingInfoResp", billingInfoResp);
+          if (shippingInfoResp === 201 && billingInfoResp === 201) {
+            router.push("/cart/step/2");
+          }
+        }}
+      >
+        Next
+      </Button>
     </div>
   );
 };
@@ -139,6 +283,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     props: {
       shippingInfo,
       billingInfo,
+      cartToken,
     },
   };
 };

--- a/src/storefront/pages/cart/step/1.tsx
+++ b/src/storefront/pages/cart/step/1.tsx
@@ -39,6 +39,7 @@ import Grid from "@mui/material/Grid";
 import { IBillingInfo, IShippingInfo } from "@/types/cart";
 import { countryListAPI } from "@/pages/api/country";
 import { ICountry } from "@/types/country";
+import CartButtonRow from "@/components/Cart/ButtonRow";
 
 interface ICartStep1PageProps {
   shippingInfo: any;
@@ -234,43 +235,22 @@ const CartStep1Page = ({
           </div>
         </Grid>
       </Grid>
-      <Grid
-        container
-        spacing={{ xs: 0, md: 4, lg: 4 }}
-        columns={{ xs: 10, sm: 10, md: 12 }}
-        pt={4}
-      >
-        <Grid container item xs={2} sm={2} md={2} direction="column" pt={4}>
-          <Typography
-            variant="body1"
-            sx={{
-              cursor: "pointer",
-              textDecoration: "underline",
-              "&:hover": {
-                color: "primary.main",
-              },
-            }}
-            onClick={() => {
-              router.push("/cart");
-            }}
-          >
-            Back to cart
-          </Typography>
-        </Grid>
-        <Grid container item xs={6} sm={7} md={7} direction="column" pt={4} />
-        <Grid container item xs={1} sm={1} md={1} direction="column" pt={4}>
-          <Button
-            variant={"contained"}
-            disabled={
-              !validShippingInfo ||
-              (!validBillingInfo && billingRadioSelect === "NEW")
-            }
-            onClick={async () => submitForm()}
-          >
-            Next
-          </Button>
-        </Grid>
-      </Grid>
+      <CartButtonRow
+        prev={{
+          title: "Back to cart",
+          onClick: () => {
+            router.push("/cart");
+          },
+          disabled: false,
+        }}
+        next={{
+          title: "Next",
+          onClick: async () => submitForm(),
+          disabled:
+            !validShippingInfo ||
+            (!validBillingInfo && billingRadioSelect === "NEW"),
+        }}
+      />
     </div>
   );
 };

--- a/src/storefront/pages/cart/step/1.tsx
+++ b/src/storefront/pages/cart/step/1.tsx
@@ -10,6 +10,7 @@ import { cartAPI } from "@/pages/api/cart/[token]";
 import { cartBillingInfoAPI } from "@/pages/api/cart/[token]/billing-info";
 import { cartShippingInfoAPI } from "@/pages/api/cart/[token]/shipping-info";
 import { IBillingInfo, IShippingInfo } from "@/types/cart";
+import Grid from "@mui/material/Grid";
 import { GetServerSideProps, NextApiRequest, NextApiResponse } from "next";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -48,32 +49,42 @@ const CartStep1Page = ({ shippingInfo, billingInfo }: ICartStep1PageProps) => {
   console.log("shippingInfoState", shippingInfoState);
   return (
     <div className="container">
-      <ShippingInfoForm
-        first_name={shippingInfoState.first_name}
-        surname={shippingInfoState.surname}
-        email={shippingInfoState.email}
-        phone={shippingInfoState.phone}
-        additional_info={shippingInfoState.additional_info}
-        street={shippingInfoState.street}
-        city={shippingInfoState.city}
-        postal_code={shippingInfoState.postal_code}
-        country={shippingInfoState.country}
-        setIsFormValid={setValidShippingInfo}
-      />
-      Shipping is valid: {validShippingInfo ? "true" : "false"}
-      <BillingInfoForm
-        first_name={billingInfoState.first_name}
-        surname={billingInfoState.surname}
-        company_name={billingInfoState.company_name}
-        company_id={billingInfoState.company_id}
-        vat_number={billingInfoState.vat_number}
-        street={billingInfoState.street}
-        city={billingInfoState.city}
-        postal_code={billingInfoState.postal_code}
-        country={billingInfoState.country}
-        setIsFormValid={setValidBillingInfo}
-      />
-      Billing is valid: {validBillingInfo ? "true" : "false"}
+      <Grid
+        container
+        spacing={{ xs: 2, md: 3 }}
+        columns={{ xs: 4, sm: 8, md: 12 }}
+      >
+        <Grid container item xs={2} sm={4} md={4} direction="column">
+          <ShippingInfoForm
+            first_name={shippingInfoState.first_name}
+            surname={shippingInfoState.surname}
+            email={shippingInfoState.email}
+            phone={shippingInfoState.phone}
+            additional_info={shippingInfoState.additional_info}
+            street={shippingInfoState.street}
+            city={shippingInfoState.city}
+            postal_code={shippingInfoState.postal_code}
+            country={shippingInfoState.country}
+            setIsFormValid={setValidShippingInfo}
+          />
+          Shipping is valid: {validShippingInfo ? "true" : "false"}
+        </Grid>
+        <Grid container item xs={2} sm={4} md={4} direction="column">
+          <BillingInfoForm
+            first_name={billingInfoState.first_name}
+            surname={billingInfoState.surname}
+            company_name={billingInfoState.company_name}
+            company_id={billingInfoState.company_id}
+            vat_number={billingInfoState.vat_number}
+            street={billingInfoState.street}
+            city={billingInfoState.city}
+            postal_code={billingInfoState.postal_code}
+            country={billingInfoState.country}
+            setIsFormValid={setValidBillingInfo}
+          />
+          Billing is valid: {validBillingInfo ? "true" : "false"}
+        </Grid>
+      </Grid>
     </div>
   );
 };

--- a/src/storefront/pages/cart/step/1.tsx
+++ b/src/storefront/pages/cart/step/1.tsx
@@ -1,0 +1,108 @@
+import ShippingInfoForm, {
+  IShippingInfoFormProps,
+  shippingInfoInitialData,
+} from "@/components/Forms/ShippingInfoForm";
+import { cartAPI } from "@/pages/api/cart/[token]";
+import { cartBillingInfoAPI } from "@/pages/api/cart/[token]/billing-info";
+import { cartShippingInfoAPI } from "@/pages/api/cart/[token]/shipping-info";
+import { IBillingInfo, IShippingInfo } from "@/types/cart";
+import { GetServerSideProps, NextApiRequest, NextApiResponse } from "next";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+interface ICartStep1PageProps {
+  shippingInfo: any;
+  billingInfo: any;
+}
+
+const CartStep1Page = ({ shippingInfo, billingInfo }: ICartStep1PageProps) => {
+  /**
+   * Step 1 page of the cart consist of the:
+   * - shipping info
+   * - billing info
+   */
+
+  const [validShippingInfo, setValidShippingInfo] = useState<boolean>(false);
+  const [shippingInfoState, setShippingInfoState] =
+    useState<IShippingInfoFormProps>({} as IShippingInfoFormProps);
+
+  if (Object.keys(shippingInfoState)?.length === 0) {
+    setShippingInfoState(
+      shippingInfoInitialData(shippingInfo, setShippingInfoState)
+    );
+  }
+
+  console.log("shippingInfoState", shippingInfoState);
+  return (
+    <div className="container">
+      <ShippingInfoForm
+        first_name={shippingInfoState.first_name}
+        surname={shippingInfoState.surname}
+        email={shippingInfoState.email}
+        phone={shippingInfoState.phone}
+        additional_info={shippingInfoState.additional_info}
+        street={shippingInfoState.street}
+        city={shippingInfoState.city}
+        postal_code={shippingInfoState.postal_code}
+        country={shippingInfoState.country}
+        setIsFormValid={setValidShippingInfo}
+      />
+      Shipping is valid: {validShippingInfo ? "true" : "false"}
+    </div>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  /**
+   * Fetch the cart from the API
+   */
+
+  const { req, res } = context;
+  const { cartToken } = req.cookies;
+
+  if (cartToken === undefined || cartToken === null) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  }
+
+  const shippingInfo = await cartShippingInfoAPI(
+    "GET",
+    cartToken,
+    req as NextApiRequest,
+    res as NextApiResponse
+  );
+
+  const billingInfo = await cartBillingInfoAPI(
+    "GET",
+    cartToken,
+    req as NextApiRequest,
+    res as NextApiResponse
+  );
+
+  if (
+    shippingInfo === undefined ||
+    billingInfo === null ||
+    billingInfo === undefined ||
+    billingInfo === null
+  ) {
+    // if there's no cart, redirect to the homepage
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: {
+      shippingInfo,
+      billingInfo,
+    },
+  };
+};
+
+export default CartStep1Page;

--- a/src/storefront/pages/cart/step/1.tsx
+++ b/src/storefront/pages/cart/step/1.tsx
@@ -7,7 +7,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 // api
 import { putBillingInfo, putShippingInfo } from "@/api/cart/info";
-import { cartAPI } from "@/pages/api/cart/[token]";
 import { cartBillingInfoAPI } from "@/pages/api/cart/[token]/billing-info";
 import { cartShippingInfoAPI } from "@/pages/api/cart/[token]/shipping-info";
 

--- a/src/storefront/types/cart.ts
+++ b/src/storefront/types/cart.ts
@@ -47,3 +47,8 @@ export interface IShippingInfo extends Address {
   phone: string;
   additional_info: string;
 }
+
+export interface ICountryOption {
+  code: string;
+  name: string;
+}

--- a/src/storefront/types/cart.ts
+++ b/src/storefront/types/cart.ts
@@ -25,3 +25,25 @@ export interface ICart {
 export interface ICartToken {
   token: string;
 }
+
+export interface Address {
+  id: number;
+  first_name: string;
+  surname: string;
+  street: string;
+  city: string;
+  postal_code: string;
+  country: number;
+}
+
+export interface IBillingInfo extends Address {
+  company_name: string;
+  company_id: string;
+  vat_number: string;
+}
+
+export interface IShippingInfo extends Address {
+  email: string;
+  phone: string;
+  additional_info: string;
+}

--- a/src/storefront/types/cart.ts
+++ b/src/storefront/types/cart.ts
@@ -27,13 +27,13 @@ export interface ICartToken {
 }
 
 export interface Address {
-  id: number;
+  id?: number;
   first_name: string;
   surname: string;
   street: string;
   city: string;
   postal_code: string;
-  country: number;
+  country: string;
 }
 
 export interface IBillingInfo extends Address {

--- a/src/storefront/types/common.ts
+++ b/src/storefront/types/common.ts
@@ -1,1 +1,12 @@
 export type HTTPMETHOD = "GET" | "POST" | "PUT" | "DELETE";
+
+export interface IValidatedInputField {
+  value: string;
+  isValid?: boolean;
+  setter: (value: string) => void;
+  setIsValid?: (value: boolean) => void;
+  validator?: (value: string) => boolean;
+  isRequired?: boolean;
+  errorMessage?: string;
+  label?: string;
+}

--- a/src/storefront/types/country.ts
+++ b/src/storefront/types/country.ts
@@ -1,0 +1,6 @@
+export interface ICountry {
+  code: string;
+  name: string;
+  locale: string;
+  default_price_list: string;
+}


### PR DESCRIPTION
Added shipping/billing info form as a step 1 of our cart/checkout process 🤑 💰.
In the future we have to add option to select saved address for logged-in user, now it's not supported and user has to fill their address into the form.

All required fields have some sort of basic validation (length/regex). 

I also added option to select billing info "same as shipping" so that user doen't have to type the same thing twice. See how it works when you return back (there's a function that checks on initial load whether they're the same and if yes, it doesn't toggle the form 😊 )

`PUT` to the backend also works (with redirect to the next step)

And also - `country` field. I added option to disable it, since I think it's good idea not to allow user to change their country in the checkout process (we'd have to recalculate whole cart, etc.). So I'd say - nice to have.

Anyways, this PR should allow completetion of #53 (address edit) since both shipping/billing components are quite well reusable I think. It's just neccessary to follow flow show in this step 1 (mainly filling initial data/validators and then parsing/exporting valid state to address object).

Hope you guys like it!


https://github.com/ecoseller/ecoseller/assets/34132752/c56cf931-a7c9-4dce-8b3c-063c21e27b7e


Holy shit, it's enormous and I don't know why, 3,5k LOC wtf... I checked out from @VL-CZ 's #258 so that I can take advantage of some things so let's see what happens after his merge.. 😢 .

