### PR TITLE
[H-2]: fixed bug on setting product prices

### DIFF
--- a/src/dashboard/components/Dashboard/Catalog/Products/Editor/Product/ProductVariantPricesEditor.tsx
+++ b/src/dashboard/components/Dashboard/Catalog/Products/Editor/Product/ProductVariantPricesEditor.tsx
@@ -90,16 +90,17 @@ const ProductVariantPricesEditor = ({
       });
       return;
     }
-    console.log("settingrows", rows);
 
     const variantsToSet = rows.map(
       (row) =>
         ({
-          ...(row as IProductVariant),
+          // ...(row as IProductVariant), <-- this line caused the ugly bug where 99% of data of product variant (except for price) was lost
+          ...(state.product_variants as IProductVariant[]).find(
+            (productVariant: IProductVariant) => productVariant.sku == row.sku
+          ), // <-- this line fixes the bug by finding the product variant in the state and using it's data
           price: serializeProductVariantPricesFromRow(row, pricelistsData),
         } as IProductVariant)
     );
-    console.log("settingrows2", rows, variantsToSet);
 
     dispatch({
       type: ActionSetProduct.SETPRODUCTVARIANTS,

--- a/src/dashboard/components/Dashboard/Catalog/Products/Editor/Product/ProductVariantsEditor.tsx
+++ b/src/dashboard/components/Dashboard/Catalog/Products/Editor/Product/ProductVariantsEditor.tsx
@@ -158,7 +158,6 @@ const ProductVariantsEditor = ({
     if (!updateMainState) {
       return;
     }
-    console.log("updateMainState-Variant", updateMainState);
     setUpdateMainState(false);
 
     if (!rows || rows?.length == 0) {
@@ -181,7 +180,6 @@ const ProductVariantsEditor = ({
           price: serializeProductVariantPricesFromRow(row, pricelistsData),
         } as IProductVariant)
     );
-    console.log("settingrows2", rows, variantsToSet);
 
     dispatch({
       type: ActionSetProduct.SETPRODUCTVARIANTS,


### PR DESCRIPTION
Thanks @VL-CZ for noticing this issue.

For context: when editing product and setting prices/discounts, it wiped off all the data attached to the product variant 😂 (like attribtues, stock qty, etc.).
