### PR TITLE
[H-11]: Fixed elasticsearch paths

### DIFF
--- a/src/backend/elasticsearch/Dockerfile
+++ b/src/backend/elasticsearch/Dockerfile
@@ -11,4 +11,5 @@ RUN  yum -y install wget
 COPY ./download_hunspell.sh /usr/share/elasticsearch/config/
 COPY ./tmp/hunspell.txt /usr/share/elasticsearch/tmp/
 RUN chmod +x ./config/download_hunspell.sh
-RUN ./config/download_hunspell.sh
+WORKDIR /usr/share/elasticsearch/config
+RUN ./download_hunspell.sh

--- a/src/backend/elasticsearch/download_hunspell.sh
+++ b/src/backend/elasticsearch/download_hunspell.sh
@@ -13,9 +13,9 @@ mkdir -p ./hunspell \
        echo "en_ZA en/en_ZA"; \
        echo "cs_CZ cs_CZ/cs_CZ"; \
        echo "sk_SK sk_SK/sk_SK"; \
-     } > ./tmp/hunspell.txt \
+     } > /usr/share/elasticsearch/tmp/hunspell.txt \
   && cd ./hunspell \
-  && cat ../tmp/hunspell.txt | while read line; do \
+  && cat /usr/share/elasticsearch/tmp/hunspell.txt | while read line; do \
        name=$(echo $line | awk '{print $1}'); \
        file=$(echo $line | awk '{print $2}'); \
        echo "${HUNSPELL_BASE_URL}/${file}.aff"; \


### PR DESCRIPTION
Soooorry, pushed some garbage into `master` that did not work. This downloads hunspell dictionaries into correct folders :).