### PR TITLE
[T–302]: Fetch CMS categories on storefront

### DIFF
--- a/src/backend/core/cms/serializers.py
+++ b/src/backend/core/cms/serializers.py
@@ -187,3 +187,22 @@ class PageCateogryTypeDashboardSerializer(
     class Meta:
         model = PageCategoryType
         fields = ("id", "identifier")
+
+
+class PageCategoryStorefrontPreviewSerializer(
+    TranslatedSerializerMixin, serializers.ModelSerializer
+):
+    page = PagePolymorphicPreviewSerializer(
+        source="filtered_page", many=True, read_only=True
+    )
+
+    class Meta:
+        model = PageCategory
+        fields = (
+            "id",
+            "title",
+            "image",
+            "code",
+            "published",
+            "page",
+        )

--- a/src/backend/core/cms/urls.py
+++ b/src/backend/core/cms/urls.py
@@ -9,6 +9,10 @@ urlpatterns = [
     path("category/type/", views.PageCategoryTypeDashboardView.as_view()),
     path("category/type/<int:pk>/", views.PageTypeDashboardDetailView.as_view()),
     path("category/type/<int:pk>/pages/", views.PageTypePagesDashboardView.as_view()),
+    path(
+        "storefront/category/type/<str:type>/pages/",
+        views.PageTypePagesStorefrontView.as_view(),
+    ),
     path("category/", views.PageCategoryDashboardView.as_view()),
     path("category/<int:pk>/", views.PageCategoryDashboardDetailView.as_view()),
     path("category/<int:pk>/pages/", views.PageCategoryPagesDashboardView.as_view()),

--- a/src/backend/core/cms/views.py
+++ b/src/backend/core/cms/views.py
@@ -1,8 +1,12 @@
-from rest_framework.status import HTTP_201_CREATED, HTTP_400_BAD_REQUEST
+from rest_framework.status import (
+    HTTP_201_CREATED,
+    HTTP_400_BAD_REQUEST,
+)
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny
-from rest_framework.generics import RetrieveUpdateDestroyAPIView
+from rest_framework.generics import RetrieveUpdateDestroyAPIView, ListAPIView
+from django.db.models import Prefetch
 
 # from django.contrib.auth.models import User
 from .models import (
@@ -19,6 +23,7 @@ from .serializers import (
     PageFrontendDashboardSerializer,
     PageCategoryDashboardSerializer,
     PageCateogryTypeDashboardSerializer,
+    PageCategoryStorefrontPreviewSerializer,
 )
 
 from roles.decorator import check_user_is_staff_decorator
@@ -205,3 +210,37 @@ class PageTypePagesDashboardView(APIView):
         Gets all pages in a type.
         """
         raise NotImplementedError
+
+
+class PageTypePagesStorefrontView(ListAPIView):
+    """
+    View for listing all pages in a type (frontend)
+    """
+
+    permission_classes = (AllowAny,)
+    serializer_class = PageCategoryStorefrontPreviewSerializer
+
+    def get_queryset(self):
+        type = self.kwargs["type"]
+        type_obj = PageCategoryType.objects.filter(identifier=type)
+        return PageCategory.objects.filter(
+            published=True, type__in=type_obj
+        ).prefetch_related(
+            Prefetch(
+                "page",
+                queryset=Page.objects.filter(published=True),
+                to_attr="filtered_page",
+            )
+        )
+
+    def get(self, request, type):
+        """
+        Gets all pages in a type.
+        """
+        queryset = self.get_queryset()
+        print(queryset)
+        serializer = self.serializer_class(
+            queryset, many=True, context={"request": request}
+        )
+        data = serializer.data
+        return Response(data)

--- a/src/backend/core/review/migrations/0001_initial.py
+++ b/src/backend/core/review/migrations/0001_initial.py
@@ -6,7 +6,6 @@ import uuid
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/src/backend/core/review/migrations/0002_review_product_variant.py
+++ b/src/backend/core/review/migrations/0002_review_product_variant.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("product", "0038_attributetype_baseattribute_and_more"),
         ("review", "0001_initial"),

--- a/src/backend/core/review/migrations/0003_review_country.py
+++ b/src/backend/core/review/migrations/0003_review_country.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("review", "0002_review_product_variant"),
     ]

--- a/src/storefront/components/Footer/FooterLine.tsx
+++ b/src/storefront/components/Footer/FooterLine.tsx
@@ -53,12 +53,6 @@ const Footer = () => {
               <Item>GreatCompany © 2023</Item>
             </Grid>
             <Grid>
-              <Item>Privacy Policy</Item>
-            </Grid>
-            <Grid>
-              <Item>Terms of Service</Item>
-            </Grid>
-            <Grid>
               <Item onClick={() => toggleDisclaimer(true)}>Cookies</Item>
             </Grid>
           </Grid>

--- a/src/storefront/components/Footer/FooterMenu.tsx
+++ b/src/storefront/components/Footer/FooterMenu.tsx
@@ -15,6 +15,8 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Unstable_Grid2";
 import { MaxWidthWrapper } from "../MaxWidthWrapper";
+import useSWR from "swr";
+import { IPageCategory } from "@/types/cms";
 
 const StyledFooter = styled("footer")(({ theme }) => ({
   backgroundColor: "#F5F5F5",
@@ -49,6 +51,13 @@ const FancyListItem = styled("li")(({ theme }) => ({
 }));
 
 const FooterMenu = () => {
+  const { data } = useSWR<IPageCategory[]>(
+    `api/cms/type/FOOTER`,
+    (url: string) => fetch(url).then((res) => res.json())
+  );
+
+  console.log("FOOTER", data);
+
   return (
     <StyledFooter>
       <MaxWidthWrapper>
@@ -72,46 +81,24 @@ const FooterMenu = () => {
             </Grid>
           </Grid>
           <Grid container xs={12} md={7} lg={8} spacing={4}>
-            <Grid xs={6} lg={3}>
-              <Item>
-                <ItemHeading>Category A</ItemHeading>
-                <Box component="ul" aria-labelledby="category-a" sx={{ pl: 2 }}>
-                  <FancyListItem>Link 1.1</FancyListItem>
-                  <FancyListItem>Link 1.2</FancyListItem>
-                  <FancyListItem>Link 1.3</FancyListItem>
-                </Box>
-              </Item>
-            </Grid>
-            <Grid xs={6} lg={3}>
-              <Item>
-                <ItemHeading>Category B</ItemHeading>
-                <Box component="ul" aria-labelledby="category-b" sx={{ pl: 2 }}>
-                  <FancyListItem>Link 2.1</FancyListItem>
-                  <FancyListItem>Link 2.2</FancyListItem>
-                  <FancyListItem>Link 2.3</FancyListItem>
-                </Box>
-              </Item>
-            </Grid>
-            <Grid xs={6} lg={3}>
-              <Item>
-                <ItemHeading>Category C</ItemHeading>
-                <Box component="ul" aria-labelledby="category-c" sx={{ pl: 2 }}>
-                  <FancyListItem>Link 3.1</FancyListItem>
-                  <FancyListItem>Link 3.2</FancyListItem>
-                  <FancyListItem>Link 3.3</FancyListItem>
-                </Box>
-              </Item>
-            </Grid>
-            <Grid xs={6} lg={3}>
-              <Item>
-                <ItemHeading>Category D</ItemHeading>
-                <Box component="ul" aria-labelledby="category-d" sx={{ pl: 2 }}>
-                  <FancyListItem>Link 4.1</FancyListItem>
-                  <FancyListItem>Link 4.2</FancyListItem>
-                  <FancyListItem>Link 4.3</FancyListItem>
-                </Box>
-              </Item>
-            </Grid>
+            {data?.map((category) => (
+              <Grid xs={6} lg={3} key={category.id}>
+                <Item>
+                  <ItemHeading>{category.title}</ItemHeading>
+                  <Box
+                    component="ul"
+                    aria-labelledby="category-a"
+                    sx={{ pl: 2 }}
+                  >
+                    {category?.page?.map((page) => (
+                      <Link href={page.slug} key={page.id}>
+                        <FancyListItem>{page.title}</FancyListItem>
+                      </Link>
+                    ))}
+                  </Box>
+                </Item>
+              </Grid>
+            ))}
           </Grid>
         </Grid>
       </MaxWidthWrapper>

--- a/src/storefront/components/Header/TopLine.tsx
+++ b/src/storefront/components/Header/TopLine.tsx
@@ -14,6 +14,8 @@ import Link from "next/link";
 import { MaxWidthWrapper } from "../MaxWidthWrapper";
 import Grid from "@mui/material/Unstable_Grid2";
 import CountrySelect from "../Common/CountrySelect";
+import useSWR from "swr";
+import { IPageCategory } from "@/types/cms";
 // components
 // utils
 
@@ -34,6 +36,15 @@ const TopLineContainer = styled("div")(({ theme }) => ({
 }));
 
 const TopLine = () => {
+  const { data } = useSWR<IPageCategory[]>(
+    `/api/cms/type/HEADER`,
+    (url: string) => fetch(url).then((res) => res.json())
+  );
+
+  console.log(
+    "HEADER",
+    data?.map((category) => category?.page?.map((page) => page?.title))
+  );
   return (
     <TopLineContainer>
       <MaxWidthWrapper>
@@ -51,44 +62,29 @@ const TopLine = () => {
               columnSpacing={1}
               sx={{ pr: 2, order: { xs: 2, sm: 1 } }}
             >
-              <Grid>
-                <Item>
-                  <Typography
-                    variant="subtitle2"
-                    sx={{ flexGrow: 1 }}
-                    component={Link}
-                    href="/contact"
-                    shallow={false}
-                    prefetch={false}
-                    style={{
-                      textDecoration: "none",
-                      color: "inherit",
-                      cursor: "pointer",
-                    }}
-                  >
-                    Contact
-                  </Typography>
-                </Item>
-              </Grid>
-              <Grid>
-                <Item>
-                  <Typography
-                    variant="subtitle2"
-                    sx={{ flexGrow: 1 }}
-                    component={Link}
-                    href="/category"
-                    shallow={false}
-                    prefetch={false}
-                    style={{
-                      textDecoration: "none",
-                      color: "inherit",
-                      cursor: "pointer",
-                    }}
-                  >
-                    Return & Exchange
-                  </Typography>
-                </Item>
-              </Grid>
+              {data?.map((category) =>
+                category?.page?.map((page) => (
+                  <Grid>
+                    <Item>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{ flexGrow: 1 }}
+                        component={Link}
+                        href={`/${page?.slug}`}
+                        shallow={false}
+                        prefetch={false}
+                        style={{
+                          textDecoration: "none",
+                          color: "inherit",
+                          cursor: "pointer",
+                        }}
+                      >
+                        {page?.title}
+                      </Typography>
+                    </Item>
+                  </Grid>
+                ))
+              )}
               <Grid>
                 <Item>
                   <CountrySelect />

--- a/src/storefront/components/Header/TopLine.tsx
+++ b/src/storefront/components/Header/TopLine.tsx
@@ -64,7 +64,7 @@ const TopLine = () => {
             >
               {data?.map((category) =>
                 category?.page?.map((page) => (
-                  <Grid>
+                  <Grid key={page.id}>
                     <Item>
                       <Typography
                         variant="subtitle2"

--- a/src/storefront/pages/api/cms/type/[identifier].tsx
+++ b/src/storefront/pages/api/cms/type/[identifier].tsx
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { api, setRequestResponse } from "@/utils/interceptors/api";
 import { HTTPMETHOD } from "@/types/common";
 
-export const orderSubmitAPI = async (
+export const pageCategoryTypeAPI = async (
   method: HTTPMETHOD,
   identifier: string,
   req: NextApiRequest,
@@ -29,7 +29,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { identifier } = query;
 
   if (method == "GET") {
-    return orderSubmitAPI("GET", identifier as string, req, res)
+    return pageCategoryTypeAPI("GET", identifier as string, req, res)
       .then((data) => res.status(200).json(data))
       .catch((error) => res.status(400).json(error.response.data));
   }

--- a/src/storefront/pages/api/cms/type/[identifier].tsx
+++ b/src/storefront/pages/api/cms/type/[identifier].tsx
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { api, setRequestResponse } from "@/utils/interceptors/api";
+import { HTTPMETHOD } from "@/types/common";
+
+export const orderSubmitAPI = async (
+  method: HTTPMETHOD,
+  identifier: string,
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
+  if (req && res) {
+    setRequestResponse(req, res);
+  }
+
+  let url = `cms/storefront/category/type/${identifier}/pages/`;
+
+  if (method === "GET") {
+    return await api.get(url).then((response) => response.data);
+  } else {
+    throw new Error("Method not supported");
+  }
+};
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  /**
+   * This is a wrapper for the CMS API in the backend to list all the categories and their pages for the footer menu.
+   */
+  const { method, query } = req;
+  const { identifier } = query;
+
+  if (method == "GET") {
+    return orderSubmitAPI("GET", identifier as string, req, res)
+      .then((data) => res.status(200).json(data))
+      .catch((error) => res.status(400).json(error.response.data));
+  }
+  return res.status(404).json({ message: "Method not supported" });
+};
+
+export default handler;

--- a/src/storefront/types/cms.ts
+++ b/src/storefront/types/cms.ts
@@ -1,0 +1,13 @@
+export interface IPageCategory {
+  id: number;
+  title: string;
+  code: string;
+  page: IPagePreview[];
+}
+
+export interface IPagePreview {
+  id: number;
+  title: string;
+  slug: string;
+  resourcetype: "PageCMS" | "PageFrontend";
+}


### PR DESCRIPTION
Implemented fetching of CMS categories on the storefront. So for example in the footer and header we need to fetch list of pages (based on the `PageCategoryType`) with previous of exact pages attached to the category.
Hope you like it, pals.


https://github.com/ecoseller/ecoseller/assets/34132752/e15dc63f-7e14-4b19-a951-9c6f772e2b98


https://github.com/ecoseller/ecoseller/assets/34132752/235a2947-2351-4f69-a019-d722bc18d952


