### PR TITLE
[H-18] added missing i18n texts

### DIFF
--- a/src/storefront/components/Category/Filters/NumericFilterSelect.tsx
+++ b/src/storefront/components/Category/Filters/NumericFilterSelect.tsx
@@ -7,6 +7,7 @@ import {
 import { INumericAttributeFilterWithOptions } from "@/pages/category/[id]/[slug]";
 import MenuItem from "@mui/material/MenuItem";
 import React from "react";
+import { useTranslation } from "next-i18next";
 
 interface INumericFilterSelectProps {
   filter: INumericAttributeFilterWithOptions;
@@ -21,7 +22,9 @@ const NumericFilterSelect = ({
   label,
   handleChange,
 }: INumericFilterSelectProps) => {
+  const { t } = useTranslation("category");
   const selectId = `filter-select-${filter.id}`;
+
   return (
     <FormControl sx={{ m: 1, minWidth: 100 }}>
       <InputLabel id={`${selectId}-label`}>{label}</InputLabel>
@@ -34,7 +37,7 @@ const NumericFilterSelect = ({
         onChange={(event) => handleChange(event)}
       >
         <MenuItem value="">
-          <em>None</em>
+          <em>{t("filter-empty")}</em>
         </MenuItem>
         {filter.possible_values.map((val) => (
           <MenuItem key={val.id} value={val.id}>

--- a/src/storefront/components/Category/ProductFilters.tsx
+++ b/src/storefront/components/Category/ProductFilters.tsx
@@ -16,6 +16,7 @@ import Typography from "@mui/material/Typography";
 import NumericFilterSelect from "@/components/Category/Filters/NumericFilterSelect";
 import CancelIcon from "@mui/icons-material/Cancel";
 import Button from "@mui/material/Button";
+import { useTranslation } from "next-i18next";
 
 interface IProductFiltersProps {
   filters: IFilters;
@@ -38,6 +39,8 @@ const ProductFilters = ({
   updateNumericFilter,
   setEmptyFilters,
 }: IProductFiltersProps) => {
+  const { t } = useTranslation(["category", "common"]);
+
   const handleTextualFilterChange = (
     id: number,
     event: SelectChangeEvent<number[]>
@@ -64,7 +67,7 @@ const ProductFilters = ({
   };
 
   return (
-    <CollapsableContentWithTitle title="Filters" defaultOpen={true}>
+    <CollapsableContentWithTitle title={t("filters")} defaultOpen={true}>
       <Grid container spacing={{ xs: 1, sm: 2 }}>
         {Object.entries(filters.textual).map(([id, filter]) => {
           const selectId = `filter-select-${id}`;
@@ -118,7 +121,7 @@ const ProductFilters = ({
                 <div>
                   <NumericFilterSelect
                     filter={filter}
-                    label="From"
+                    label={t("from", { ns: "common" })}
                     selectedValueId={filter.min_value_id}
                     handleChange={(event) =>
                       handleNumericFilterChange(
@@ -130,7 +133,7 @@ const ProductFilters = ({
                   />
                   <NumericFilterSelect
                     filter={filter}
-                    label="To"
+                    label={t("to", { ns: "common" })}
                     selectedValueId={filter.max_value_id}
                     handleChange={(event) =>
                       handleNumericFilterChange(
@@ -151,7 +154,7 @@ const ProductFilters = ({
         startIcon={<CancelIcon />}
         onClick={() => setEmptyFilters()}
       >
-        Cancel filters
+        {t("cancel-filters")}
       </Button>
     </CollapsableContentWithTitle>
   );

--- a/src/storefront/components/ProductDetail/ProductVariants/Row.tsx
+++ b/src/storefront/components/ProductDetail/ProductVariants/Row.tsx
@@ -32,16 +32,7 @@ import { Typography, useMediaQuery, useTheme } from "@mui/material";
 import { serializeAttributes } from "@/utils/attributes";
 import QuantitySelect from "@/components/Common/QuantitySelect";
 import DiscountText from "@/components/Generic/DiscountText";
-
-const StockQuantity = ({ quantity }: { quantity: number }) => {
-  if (quantity > 5) {
-    return <span style={{ color: "green" }}>In Stock</span>;
-  } else if (quantity > 0) {
-    return <span style={{ color: "orange" }}>Low Stock</span>;
-  } else {
-    return <span style={{ color: "red" }}>Out of Stock</span>;
-  }
-};
+import { useTranslation } from "next-i18next";
 
 const ProductVariantRow = ({
   variant,
@@ -56,12 +47,24 @@ const ProductVariantRow = ({
 }) => {
   const { addToCart } = useCart();
   const { query } = useRouter();
+  const { t } = useTranslation("product");
 
   const [qty, setQty] = useState(1);
 
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"));
   console.log("qty", qty, productId);
+
+  const StockQuantity = ({ quantity }: { quantity: number }) => {
+    if (quantity > 5) {
+      return <span style={{ color: "green" }}>{t("in-stock")}</span>;
+    } else if (quantity > 0) {
+      return <span style={{ color: "orange" }}>{t("low-stock")}</span>;
+    } else {
+      return <span style={{ color: "red" }}>{t("out-of-stock")}</span>;
+    }
+  };
+
   return (
     <Grid
       container

--- a/src/storefront/public/locales/cs/category.json
+++ b/src/storefront/public/locales/cs/category.json
@@ -8,5 +8,7 @@
   "order-by-title-asc": "Dle názvu A-Z",
   "order-by-title-desc": "Dle názvu Z-A",
   "sort-by": "Řadit dle",
-  "subcategory-section-title": "Podkategorie"
+  "subcategory-section-title": "Podkategorie",
+  "filters": "Filtry",
+  "cancel-filters": "Zrušit filtry"
 }

--- a/src/storefront/public/locales/cs/category.json
+++ b/src/storefront/public/locales/cs/category.json
@@ -10,5 +10,6 @@
   "sort-by": "Řadit dle",
   "subcategory-section-title": "Podkategorie",
   "filters": "Filtry",
-  "cancel-filters": "Zrušit filtry"
+  "cancel-filters": "Zrušit filtry",
+  "filter-empty": "(Prázdné)"
 }

--- a/src/storefront/public/locales/cs/ccommon.json
+++ b/src/storefront/public/locales/cs/ccommon.json
@@ -1,3 +1,0 @@
-{
-  "ountry-label": ""
-}

--- a/src/storefront/public/locales/cs/common.json
+++ b/src/storefront/public/locales/cs/common.json
@@ -35,5 +35,6 @@
   "next": "Další",
   "save": "Uložit",
   "created-at": "Vytvořeno: {{date}}",
-  "up-to": "Až"
+  "up-to": "Až",
+  "to": "Do"
 }

--- a/src/storefront/public/locales/cs/product.json
+++ b/src/storefront/public/locales/cs/product.json
@@ -2,5 +2,8 @@
   "varinats": "Varianty",
   "recommended-products-title": "Doporučené produkty",
   "recommended-products-description": "Prohlédněte si další produkty, které by se vám mohly líbit",
-  "reviews": "Hodnocení zákazníků"
+  "reviews": "Hodnocení zákazníků",
+  "in-stock": "Na skladě",
+  "low-stock": "Posledních pár kusů",
+  "out-of-stock": "Vyprodáno"
 }

--- a/src/storefront/public/locales/en/category.json
+++ b/src/storefront/public/locales/en/category.json
@@ -8,5 +8,6 @@
   "sort-by": "Order by",
   "subcategory-section-title": "Subcategories",
   "filters": "Filters",
-  "cancel-filters": "Cancel filters"
+  "cancel-filters": "Cancel filters",
+  "filter-empty": "(Empty)"
 }

--- a/src/storefront/public/locales/en/category.json
+++ b/src/storefront/public/locales/en/category.json
@@ -6,5 +6,7 @@
   "order-by-title-asc": "By name: A-Z",
   "order-by-title-desc": "By name: Z-A",
   "sort-by": "Order by",
-  "subcategory-section-title": "Subcategories"
+  "subcategory-section-title": "Subcategories",
+  "filters": "Filters",
+  "cancel-filters": "Cancel filters"
 }

--- a/src/storefront/public/locales/en/ccommon.json
+++ b/src/storefront/public/locales/en/ccommon.json
@@ -1,3 +1,0 @@
-{
-  "ountry-label": ""
-}

--- a/src/storefront/public/locales/en/common.json
+++ b/src/storefront/public/locales/en/common.json
@@ -35,5 +35,6 @@
   "next": "Next",
   "save": "Save",
   "created-at": "Created at: {{date}}",
-  "up-to": "Up to"
+  "up-to": "Up to",
+  "to": "To"
 }

--- a/src/storefront/public/locales/en/product.json
+++ b/src/storefront/public/locales/en/product.json
@@ -2,5 +2,8 @@
   "varinats": "Variants",
   "recommended-products-title": "Recommended products",
   "recommended-products-description": "See other products that you might like",
-  "reviews": "Cusotmer reviews"
+  "reviews": "Cusotmer reviews",
+  "in-stock": "In Stock",
+  "low-stock": "Low Stock",
+  "out-of-stock": "Out of Stock"
 }

--- a/src/storefront/public/locales/en/product.json
+++ b/src/storefront/public/locales/en/product.json
@@ -2,7 +2,7 @@
   "varinats": "Variants",
   "recommended-products-title": "Recommended products",
   "recommended-products-description": "See other products that you might like",
-  "reviews": "Cusotmer reviews",
+  "reviews": "Customer reviews",
   "in-stock": "In Stock",
   "low-stock": "Low Stock",
   "out-of-stock": "Out of Stock"


### PR DESCRIPTION
No video today 😞 

I noticed several places, with hardcoded (non-localized) strings, so I fixed these (it's mostly product filters)
Also note that I deleted `ccommon` i18n namespaces (yes, there is really double `c` at the beginning, it's not a typo 🙂), since they're not used IMO
