### PR TITLE
[H-22] removed volume binding in recommender demo

### DIFF
--- a/src/docker-compose.demo.yaml
+++ b/src/docker-compose.demo.yaml
@@ -148,8 +148,8 @@ services:
     build:
       context: ./recommender_system
       target: demo # runs given branch in Dockerfile https://stackoverflow.com/a/65624157/16587316
-    volumes:
-      - ./recommender_system/app:/usr/src/app/
+    # volumes:
+      # - ./recommender_system/app:/usr/src/app/
     ports:
       - 8086:8086
     env_file:


### PR DESCRIPTION
This was causing crash of our `gh-pages` pipeline after I ran docker-compose.demo.yaml in the `gh-pages` branch to see some stuff