### PR TITLE
[H-32] serving static files via whitenoise

### DIFF
--- a/src/backend/core/core/settings.py
+++ b/src/backend/core/core/settings.py
@@ -23,6 +23,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(os.path.join(BASE_DIR, ".env"))
 
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
+print("STATIC_ROOT", STATIC_ROOT)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
@@ -32,7 +33,7 @@ SECRET_KEY = "django-insecure-^2x#dix3t(vd1yt7bdqmhs-*=tf%)td#yxuw6s$pun(#!z=c$@
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", 1)
-
+print(DEBUG)
 ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "*").split(" ")
 
 # Application definition
@@ -63,6 +64,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -214,13 +216,19 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_URL = "/static/"
 STOREFRONT_URL = os.environ.get("STOREFRONT_URL", "http://localhost:3031")
 
 # Directory where uploaded files will be stored
 # this is only for development purposes, in production S3 or similar should be used
 MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), "mediafiles")
 MEDIA_URL = "/media/"
+
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -72,3 +72,4 @@ zipp==3.8.0
 django-rq==2.8.0
 rq==1.13
 qrcode==7.4.2
+whitenoise==6.5.0


### PR DESCRIPTION
In production, static files were not served... 
Fixed with https://whitenoise.readthedocs.io/en/stable/

Don't ask me how, I just followed this thread 😂  https://stackoverflow.com/a/62211968/16587316