### PR TITLE
[H-40]: rq_worker --with-scheduler

### DIFF
--- a/src/backend/core/rq_worker.sh
+++ b/src/backend/core/rq_worker.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-python3 -u /usr/src/app/core/manage.py rqworker high low default
+python3 -u /usr/src/app/core/manage.py rqworker --with-scheduler high low default
 
 exec "$@"


### PR DESCRIPTION
I've noticed that `rqworker` might not work for scheduled jobs (`enqueue_in`) that @lakatop implemented for sending delayed review requests. 
This thing should hopefully solve it 😊 