### PR TITLE
[H-46]: Error messages for dashboard login

### DIFF
--- a/src/backend/core/user/views.py
+++ b/src/backend/core/user/views.py
@@ -3,9 +3,9 @@ from rest_framework.generics import RetrieveUpdateDestroyAPIView
 from rest_framework.generics import UpdateAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework.serializers import ValidationError
 from rest_framework_simplejwt import views as jwt_views
 from rest_framework_simplejwt.tokens import RefreshToken
-
 from core.pagination import DashboardPagination
 from roles.decorator import (
     check_user_access_decorator,
@@ -174,11 +174,15 @@ class CustomTokenObtainPairView(jwt_views.TokenObtainPairView):
             serializedData.is_valid(raise_exception=True)
             dashboardLogin = serializedData.validated_data["dashboard_login"]
             if dashboardLogin is True and not user.is_staff:
-                return Response({"error": "Not authorized"}, status=400)
+                return Response({"error": "Not authorized for this action"}, status=400)
             return response
+        except User.DoesNotExist:
+            return Response({"error": "Check provided credentials."}, status=400)
+        except ValidationError:
+            return Response({"error": "Check provided credentials."}, status=400)
         except Exception as e:
             print("Error", e)
-            return Response("Error login", status=400)
+            return Response({"error": "Error login"}, status=400)
 
 
 class PasswordView(UpdateAPIView):

--- a/src/dashboard/components/Login/LoginBox.tsx
+++ b/src/dashboard/components/Login/LoginBox.tsx
@@ -9,6 +9,7 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
 import Link from "next/link";
+import Alert from "@mui/material/Alert";
 // components
 import Emoji from "../Emoji";
 // styles
@@ -26,8 +27,9 @@ import jwt_decode from "jwt-decode";
 const LoginBox = ({}) => {
   const router = useRouter();
 
-  const [email, setEmail] = useState<string>("admin@example.com");
-  const [password, setPassword] = useState<string>("admin");
+  const [email, setEmail] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
+  const [error, setError] = useState<string>("");
 
   return (
     <>
@@ -89,6 +91,15 @@ const LoginBox = ({}) => {
             })
               .then((res) => res.json())
               .then((data: any) => {
+                console.log("data", data);
+                if (data === null) {
+                  throw new Error("Invalid credentials");
+                }
+                if (data.error) {
+                  throw new Error(data.error);
+                }
+                setError("");
+
                 const accessToken = data.access;
                 const refreshToken = data.refresh;
 
@@ -113,12 +124,14 @@ const LoginBox = ({}) => {
                 router.replace("/dashboard/overview");
               })
               .catch((error) => {
-                console.log(error);
+                console.log("error", error);
+                setError(error.message);
               });
           }}
         >
           Login
         </Button>
+        {error ? <Alert severity="error">{error}</Alert> : null}
       </Box>
     </>
   );

--- a/src/dashboard/components/Login/LoginBox.tsx
+++ b/src/dashboard/components/Login/LoginBox.tsx
@@ -1,6 +1,6 @@
 // /components/login/LoginBox
 // react
-import { useState } from "react";
+import { useEffect, useState } from "react";
 // next.js
 import { useRouter } from "next/router";
 // mui
@@ -27,8 +27,12 @@ import jwt_decode from "jwt-decode";
 const LoginBox = ({}) => {
   const router = useRouter();
 
-  const [email, setEmail] = useState<string>("");
-  const [password, setPassword] = useState<string>("");
+  const [email, setEmail] = useState<string>(
+    process.env.NEXT_PUBLIC_DASHBOARD_USER || ""
+  );
+  const [password, setPassword] = useState<string>(
+    process.env.NEXT_PUBLIC_DASHBOARD_PASSWORD || ""
+  );
   const [error, setError] = useState<string>("");
 
   return (

--- a/src/dashboard/pages/api/user/login/index.ts
+++ b/src/dashboard/pages/api/user/login/index.ts
@@ -32,7 +32,10 @@ export const userLoginAPI = async (
           return data;
         })
         .catch((error: any) => {
-          throw error;
+          if (error?.response?.data?.error) {
+            throw error.response.data.error;
+          }
+          throw "Error during login occured. Please check your backend service.";
         });
     default:
       throw new Error("Method not supported");
@@ -49,7 +52,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   return userLoginAPI(method as HTTPMETHOD, req, res)
     .then((data) => res.status(200).json(data))
-    .catch((error) => res.status(400).json(null));
+    .catch((error) => res.status(400).json({ error: error }));
 };
 
 export default handler;

--- a/src/docker-compose.demo.yaml
+++ b/src/docker-compose.demo.yaml
@@ -80,6 +80,8 @@ services:
       API_URL: "http://backend:8000"
       NEXT_PUBLIC_API_URL: "http://localhost:8000"
       NEXT_PUBLIC_BACKEND_API_URL: "http://backend:8000"
+      NEXT_PUBLIC_DASHBOARD_USER: "admin@example.com"
+      NEXT_PUBLIC_DASHBOARD_PASSWORD: "admin"
     volumes:
       - ./dashboard/pages:/usr/src/app/pages
       - ./dashboard/utils:/usr/src/app/utils


### PR DESCRIPTION
After noticing that we still have hardcoded user credentials on dashboard login page I noticed that we don't  show user any errors about login in. Since this is pretty crucial - because you don't know if you're inputing wrong credentials or backend service is dead, I implemented both errors (so situations when backend returns nothing (it's dead) or backend returns an error - which is then presented to the user).

![Snímek obrazovky 2023-08-29 v 8 57 24](https://github.com/ecoseller/ecoseller/assets/34132752/f52dfdf2-76cb-4680-aed2-771aba3866c9)
![Snímek obrazovky 2023-08-29 v 9 09 14](https://github.com/ecoseller/ecoseller/assets/34132752/7230e1b9-7a21-42de-81f0-741a5ed3954f)
![Snímek obrazovky 2023-08-29 v 8 51 12](https://github.com/ecoseller/ecoseller/assets/34132752/717cda81-3425-4ff9-9b1b-c038c98c01fa)
