### PR TITLE
[H-48]: fixed category page crash

### DIFF
--- a/src/storefront/components/Category/ProductCard.tsx
+++ b/src/storefront/components/Category/ProductCard.tsx
@@ -89,8 +89,8 @@ const ProductCard = ({ product }: IProductCardProps) => {
           sx={{
             objectFit: "contain",
           }}
-          image={imgPath(product.primary_image.media)}
-          title={product.primary_image.alt || ""}
+          image={imgPath(product?.primary_image?.media || "")}
+          title={product?.primary_image?.alt || ""}
         />
         <CardContent>
           <Typography gutterBottom variant="h6" component="div">

--- a/src/storefront/utils/context/country.tsx
+++ b/src/storefront/utils/context/country.tsx
@@ -50,7 +50,7 @@ export const CountryProvider = ({
       return;
     }
 
-    if (countryCookieValue && countryList.length > 0) {
+    if (countryCookieValue && countryList?.length > 0) {
       setCountryCookieAndLocale(countryCookieValue);
     } else if (countryList?.length > 0) {
       setCountryCookieAndLocale(DEFAULT_COUNTRY || countryList[0].code, true);


### PR DESCRIPTION
Okay, so this one is funny.
If in the product catalog was one single product without an image or without an `alt` at image under some funky circumstances it could have caused infinite loop of crashes on every single page.

Why? Because, if you had only top level categories, they're by default prefetched thanks to the Next `<Link>` component. Well and prefetching a page that throws `500` apparently makes the whole page crash 😂.

rip in peace ecoseller if there's more of those